### PR TITLE
fix(explorer-selector): pikespeak logo size ratio

### DIFF
--- a/apps/bos-components/src/components/ExplorerSelector.tsx
+++ b/apps/bos-components/src/components/ExplorerSelector.tsx
@@ -254,9 +254,9 @@ export default function (props: Props) {
                 New
               </span>
               <img
-                className="h-16 w-44"
+                className="h-16"
                 src="/images/pikespeak_logo.png"
-                alt="Nearblocks"
+                alt="Pikespeak"
               />
               <p className="text-nearblue-600 mt-2">Pikespeak</p>
             </a>


### PR DESCRIPTION
A simple edit of the pikespeak logo size, removing width and keeping height to have a good logo ration
from           className="h-16 w-44"  to           className="h-16"
Also edit some alt attributes which were still set to "nearblocks"