### PR TITLE
fix(bos-components): arguments are always serialized as string in contract tab

### DIFF
--- a/apps/bos-components/src/components/Contract/ViewOrChange.tsx
+++ b/apps/bos-components/src/components/Contract/ViewOrChange.tsx
@@ -48,11 +48,29 @@ const sortFields = (fields: FieldType[]) => {
   return fields;
 };
 
-const mapFeilds = (fields: FieldType[]) => {
-  const args: any = {};
+type FieldValueTypes = string | boolean | number | null;
 
-  fields.forEach((fld: FieldType) => {
-    args[fld.name] = fld.value;
+const mapFeilds = <T extends Record<string, FieldValueTypes>>(
+  fields: FieldType[],
+): T => {
+  const args: T = {} as T;
+
+  fields.forEach((fld) => {
+    let value: string | boolean | number | null = fld.value;
+
+    if (fld.type === 'number') {
+      value = Number(value);
+    } else if (fld.type === 'boolean') {
+      value =
+        value.trim().length > 0 &&
+        !['false', '0'].includes(value.toLowerCase());
+    } else if (fld.type === 'json') {
+      value = JSON.parse(value);
+    } else if (fld.type === 'null') {
+      value = null;
+    }
+
+    (args as Record<string, FieldValueTypes>)[fld.name] = value + '';
   });
 
   return args;

--- a/apps/bos-components/src/components/Contract/ViewOrChange.tsx
+++ b/apps/bos-components/src/components/Contract/ViewOrChange.tsx
@@ -25,7 +25,13 @@ import { capitalize, toSnakeCase } from '@/includes/formats';
 import ArrowRight from '@/includes/icons/ArrowRight';
 import CloseCircle from '@/includes/icons/CloseCircle';
 import Question from '@/includes/icons/Question';
-import { getConfig, handleRateLimit, isJson, uniqueId } from '@/includes/libs';
+import {
+  getConfig,
+  handleRateLimit,
+  isJson,
+  mapFeilds,
+  uniqueId,
+} from '@/includes/libs';
 import { FieldType } from '@/includes/types';
 
 const inputTypes = ['string', 'number', 'boolean', 'null', 'json'];
@@ -46,34 +52,6 @@ const sortFields = (fields: FieldType[]) => {
   });
 
   return fields;
-};
-
-type FieldValueTypes = string | boolean | number | null;
-
-const mapFeilds = <T extends Record<string, FieldValueTypes>>(
-  fields: FieldType[],
-): T => {
-  const args: T = {} as T;
-
-  fields.forEach((fld) => {
-    let value: string | boolean | number | null = fld.value;
-
-    if (fld.type === 'number') {
-      value = Number(value);
-    } else if (fld.type === 'boolean') {
-      value =
-        value.trim().length > 0 &&
-        !['false', '0'].includes(value.toLowerCase());
-    } else if (fld.type === 'json') {
-      value = JSON.parse(value);
-    } else if (fld.type === 'null') {
-      value = null;
-    }
-
-    (args as Record<string, FieldValueTypes>)[fld.name] = value + '';
-  });
-
-  return args;
 };
 
 const getDataType = (data: string) => {

--- a/apps/bos-components/src/components/Contract/ViewOrChangeAbi.tsx
+++ b/apps/bos-components/src/components/Contract/ViewOrChangeAbi.tsx
@@ -40,11 +40,29 @@ const sortFields = (fields: FieldType[]) => {
   return fields;
 };
 
-const mapFeilds = (fields: FieldType[]) => {
-  const args: any = {};
+type FieldValueTypes = string | boolean | number | null;
 
-  fields.forEach((fld: FieldType) => {
-    args[fld.name] = fld.value;
+const mapFeilds = <T extends Record<string, FieldValueTypes>>(
+  fields: FieldType[],
+): T => {
+  const args: T = {} as T;
+
+  fields.forEach((fld) => {
+    let value: string | boolean | number | null = fld.value;
+
+    if (fld.type === 'number') {
+      value = Number(value);
+    } else if (fld.type === 'boolean') {
+      value =
+        value.trim().length > 0 &&
+        !['false', '0'].includes(value.toLowerCase());
+    } else if (fld.type === 'json') {
+      value = JSON.parse(value);
+    } else if (fld.type === 'null') {
+      value = null;
+    }
+
+    (args as Record<string, FieldValueTypes>)[fld.name] = value + '';
   });
 
   return args;

--- a/apps/bos-components/src/components/Contract/ViewOrChangeAbi.tsx
+++ b/apps/bos-components/src/components/Contract/ViewOrChangeAbi.tsx
@@ -25,7 +25,7 @@ import { capitalize, toSnakeCase } from '@/includes/formats';
 import ArrowRight from '@/includes/icons/ArrowRight';
 import CloseCircle from '@/includes/icons/CloseCircle';
 import Question from '@/includes/icons/Question';
-import { uniqueId } from '@/includes/libs';
+import { mapFeilds, uniqueId } from '@/includes/libs';
 import { FieldType } from '@/includes/types';
 
 const inputTypes = ['string', 'number', 'boolean', 'null', 'json'];
@@ -38,34 +38,6 @@ const sortFields = (fields: FieldType[]) => {
   });
 
   return fields;
-};
-
-type FieldValueTypes = string | boolean | number | null;
-
-const mapFeilds = <T extends Record<string, FieldValueTypes>>(
-  fields: FieldType[],
-): T => {
-  const args: T = {} as T;
-
-  fields.forEach((fld) => {
-    let value: string | boolean | number | null = fld.value;
-
-    if (fld.type === 'number') {
-      value = Number(value);
-    } else if (fld.type === 'boolean') {
-      value =
-        value.trim().length > 0 &&
-        !['false', '0'].includes(value.toLowerCase());
-    } else if (fld.type === 'json') {
-      value = JSON.parse(value);
-    } else if (fld.type === 'null') {
-      value = null;
-    }
-
-    (args as Record<string, FieldValueTypes>)[fld.name] = value + '';
-  });
-
-  return args;
 };
 
 export default function (props: Props) {

--- a/apps/bos-components/src/includes/libs.ts
+++ b/apps/bos-components/src/includes/libs.ts
@@ -1,5 +1,5 @@
 import { localFormat, formatWithCommas } from '@/includes/formats';
-import { Debounce } from './types';
+import { Debounce, FieldType, FieldValueTypes } from './types';
 
 export function convertAmountToReadableString(amount: string, type: string) {
   if (!amount) return null;
@@ -212,4 +212,28 @@ export function handleRateLimit(
       Loading();
     }
   }
+}
+
+export function mapFeilds(fields: FieldType[]) {
+  const args = {};
+
+  fields.forEach((fld) => {
+    let value: string | boolean | number | null = fld.value;
+
+    if (fld.type === 'number') {
+      value = Number(value);
+    } else if (fld.type === 'boolean') {
+      value =
+        value.trim().length > 0 &&
+        !['false', '0'].includes(value.toLowerCase());
+    } else if (fld.type === 'json') {
+      value = JSON.parse(value);
+    } else if (fld.type === 'null') {
+      value = null;
+    }
+
+    (args as Record<string, FieldValueTypes>)[fld.name] = value + '';
+  });
+
+  return args;
 }

--- a/apps/bos-components/src/includes/types.ts
+++ b/apps/bos-components/src/includes/types.ts
@@ -1530,3 +1530,5 @@ export type SchemaInfo = {
     };
   };
 };
+
+export type FieldValueTypes = string | boolean | number | null;


### PR DESCRIPTION
closes #173 