### PR TITLE
fix(app): ad unit display fixes

### DIFF
--- a/apps/app/src/components/Transactions/Details.tsx
+++ b/apps/app/src/components/Transactions/Details.tsx
@@ -546,33 +546,30 @@ const Details = (props: Props) => {
           </div>
         </div>
       )}
-      {((txn && Object.keys(txn).length > 0) ||
-        (rpcTxn && Object.keys(rpcTxn).length > 0)) && (
-        <div className="bg-white dark:bg-black-600 text-sm text-nearblue-600 dark:text-neargray-10 overflow-hidden py-1">
-          <div className="flex flex-wrap px-4 py-2">
-            <div className="flex items-start w-full md:w-1/4 mb-2 md:mb-0">
-              <Tooltip
-                className="absolute h-auto max-w-xs bg-black bg-opacity-90 z-10 text-xs text-white px-3 py-2"
-                label={'Sponsored banner advertisement'}
-              >
-                <div>
-                  <Question className="w-4 h-4 fill-current mr-1 !mt-[2px]" />
-                </div>
-              </Tooltip>
-              Sponsored:
-            </div>
-            <div className="w-full md:w-3/4 lg:h-[90px] h-[100px] break-all overflow-auto">
-              <DynamicAd
-                className="!max-w-[720px] !max-h-[100px] rounded-lg"
-                breakpoint={1024}
-                desktopUnitId="IbT2RAk1Cdc36JPkKEfCJQ=="
-                mobileUnitId="uLZF93wBs/ew1TZnm64OxQ=="
-                network="Near"
-              />
-            </div>
+      <div className="bg-white dark:bg-black-600 text-sm text-nearblue-600 dark:text-neargray-10 overflow-hidden py-1">
+        <div className="flex flex-wrap px-4 py-2">
+          <div className="flex items-start w-full md:w-1/4 mb-2 md:mb-0">
+            <Tooltip
+              className="absolute h-auto max-w-xs bg-black bg-opacity-90 z-10 text-xs text-white px-3 py-2"
+              label={'Sponsored banner advertisement'}
+            >
+              <div>
+                <Question className="w-4 h-4 fill-current mr-1 !mt-[2px]" />
+              </div>
+            </Tooltip>
+            Sponsored:
+          </div>
+          <div className="w-full md:w-3/4 lg:h-[90px] h-[100px] break-all overflow-auto">
+            <DynamicAd
+              className="lg:!max-w-[720px] !max-w-[300px] rounded-lg"
+              breakpoint={1024}
+              desktopUnitId="IbT2RAk1Cdc36JPkKEfCJQ=="
+              mobileUnitId="uLZF93wBs/ew1TZnm64OxQ=="
+              network="Near"
+            />
           </div>
         </div>
-      )}
+      </div>
       <div className="bg-white dark:bg-black-600 text-sm text-nearblue-600 dark:text-neargray-10">
         <div className="flex flex-wrap p-4">
           <div className="flex items-center w-full md:w-1/4 mb-2 md:mb-0">


### PR DESCRIPTION
Fixing issues outlined in #880.

- removed txn/rpxTxn check around the sponsored section, as txn/rpxTxn is never used in the section and instead caused issues with loading and displaying the sponsored content.

- shifted to width based size constraints for the ad to fix an display issue. Overall ad unit sizes have not changed! (mobile: 300x100px, desktop: 720x90px)

closes #880 
