### PR TITLE
revert(app): rollback to stable translation commit hash

### DIFF
--- a/apps/app/package.json
+++ b/apps/app/package.json
@@ -57,7 +57,7 @@
     "lodash": "^4.17.21",
     "near-api-js": "6.0.1",
     "nearblock-translations": "https://github.com/Nearblocks/translations.git#516d489658dea178226e90f1707935e970598c51",
-    "nearblocks-trans-next-intl": "https://github.com/Nearblocks/translations.git#669a7b07924216d0da6dfe205abc65ff0cd264fa",
+    "nearblocks-trans-next-intl": "https://github.com/Nearblocks/translations.git#1d640745ed959d09ca2ef43d895841cbd0c0f119",
     "next": "15.0.3",
     "next-intl": "^3.25.1",
     "next-runtime-env": "^3.2.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -16436,9 +16436,9 @@ near-social-vm-types@^1.0.0, near-social-vm-types@~1.0.0:
   version "0.1.2"
   resolved "https://github.com/Nearblocks/translations.git#516d489658dea178226e90f1707935e970598c51"
 
-"nearblocks-trans-next-intl@https://github.com/Nearblocks/translations.git#669a7b07924216d0da6dfe205abc65ff0cd264fa":
+"nearblocks-trans-next-intl@https://github.com/Nearblocks/translations.git#1d640745ed959d09ca2ef43d895841cbd0c0f119":
   version "0.1.2"
-  resolved "https://github.com/Nearblocks/translations.git#669a7b07924216d0da6dfe205abc65ff0cd264fa"
+  resolved "https://github.com/Nearblocks/translations.git#1d640745ed959d09ca2ef43d895841cbd0c0f119"
 
 nearley@^2.20.1:
   version "2.20.1"


### PR DESCRIPTION
- New translation commit ([[new_hash](https://github.com/Nearblocks/translations/commit/669a7b07924216d0da6dfe205abc65ff0cd264fa)]) introduced issues  
- Rolling back to stable hash ([[old_hash](https://github.com/Nearblocks/translations/commit/1d640745ed959d09ca2ef43d895841cbd0c0f119)]) 