### PR TITLE
feat(api): accounts inventory api

### DIFF
--- a/apps/api/src/libs/fetchMeta.ts
+++ b/apps/api/src/libs/fetchMeta.ts
@@ -1,0 +1,29 @@
+import { bytesParse, callFunction, getProvider } from '#libs/near';
+import redis from '#libs/redis';
+import { MtMetadata, RPCResponse } from '#types/types';
+
+const provider = getProvider();
+
+export const fetchMeta = async (
+  contract: string,
+  token_id: string,
+  EXPIRY = 60,
+): Promise<MtMetadata[]> => {
+  const cacheKey = `nep245:${contract}:meta:${token_id}`;
+
+  const metas = await redis.cache(
+    cacheKey,
+    async () => {
+      const response: RPCResponse = await callFunction(
+        provider,
+        contract,
+        'mt_metadata_token_all',
+        { token_ids: [token_id] },
+      );
+      return bytesParse(response.result) as MtMetadata[];
+    },
+    EXPIRY,
+  );
+
+  return metas;
+};

--- a/apps/api/src/libs/near.ts
+++ b/apps/api/src/libs/near.ts
@@ -11,7 +11,7 @@ export const getProvider = (url?: string) => {
   return new providers.JsonRpcProvider({ url: url ?? config.rpcUrl });
 };
 
-export const bytesParse = (input: ArrayBuffer) =>
+export const bytesParse = (input: Uint8Array) =>
   JSON.parse(Buffer.from(input).toString());
 
 export const bytesStringify = (input: unknown) =>

--- a/apps/api/src/libs/schema/v2/account.ts
+++ b/apps/api/src/libs/schema/v2/account.ts
@@ -36,11 +36,17 @@ const receiptsExport = z.object({
   }),
 });
 
+const inventory = z.object({
+  account: z.string(),
+});
+
 export type Receipts = z.infer<typeof receipts>;
 export type ReceiptsCount = z.infer<typeof receiptsCount>;
 export type ReceiptsExport = z.infer<typeof receiptsExport>;
+export type Inventory = z.infer<typeof inventory>;
 
 export default {
+  inventory,
   receipts,
   receiptsCount,
   receiptsExport,

--- a/apps/api/src/libs/schema/v2/mts.ts
+++ b/apps/api/src/libs/schema/v2/mts.ts
@@ -1,0 +1,17 @@
+import { z } from 'zod';
+
+const inventory = z.object({
+  account: z.string(),
+});
+
+const meta = z.object({
+  contract: z.string(),
+  token_id: z.string(),
+});
+
+export default {
+  inventory,
+  meta,
+};
+
+export type Inventory = z.infer<typeof inventory>;

--- a/apps/api/src/libs/utils.ts
+++ b/apps/api/src/libs/utils.ts
@@ -5,15 +5,9 @@ import { providers } from 'near-api-js';
 import { format } from 'numerable';
 
 import logger from '#libs/logger';
-import { callFunction } from '#libs/near';
+import { bytesParse, callFunction } from '#libs/near';
 import Sentry from '#libs/sentry';
-import { ValidationError } from '#types/types';
-
-type ABIResponse = {
-  block_hash: string;
-  block_height: number;
-  result: Uint8Array;
-};
+import { RPCResponse, ValidationError } from '#types/types';
 
 Big.NE = -18;
 const MS_PER_NS = Big(10).pow(6);
@@ -114,12 +108,12 @@ export const abiSchema = async (
   provider: providers.JsonRpcProvider,
   contract: string,
 ) => {
-  const response: ABIResponse = await callFunction(
+  const response: RPCResponse = await callFunction(
     provider,
     contract,
     '__contract_abi',
   );
   const decompressed = decompress(new Uint8Array(response.result));
 
-  return JSON.parse(Buffer.from(decompressed).toString());
+  return bytesParse(decompressed);
 };

--- a/apps/api/src/routes/v2/account.ts
+++ b/apps/api/src/routes/v2/account.ts
@@ -4,6 +4,7 @@ import schema from '#libs/schema/v2/account';
 import { bearerAuth } from '#middlewares/passport';
 import rateLimiter from '#middlewares/rateLimiter';
 import validator from '#middlewares/validator';
+import account from '#services/v2/account/index';
 import receipts from '#services/v2/account/receipts';
 
 const route = Router();
@@ -143,6 +144,12 @@ const routes = (app: Router) => {
     '/:account/receipts/count',
     validator(schema.receiptsCount),
     receipts.receiptsCount,
+  );
+
+  route.get(
+    '/:account/inventory/mts',
+    validator(schema.inventory),
+    account.inventory,
   );
 };
 

--- a/apps/api/src/routes/v2/index.ts
+++ b/apps/api/src/routes/v2/index.ts
@@ -2,6 +2,7 @@ import { Router } from 'express';
 
 import account from '#routes/v2/account';
 import exports from '#routes/v2/exports';
+import mts from '#routes/v2/mts';
 import txns from '#routes/v2/txns';
 
 const routes = () => {
@@ -10,6 +11,7 @@ const routes = () => {
   account(app);
   exports(app);
   txns(app);
+  mts(app);
 
   return app;
 };

--- a/apps/api/src/routes/v2/mts.ts
+++ b/apps/api/src/routes/v2/mts.ts
@@ -1,0 +1,21 @@
+import { Router } from 'express';
+
+import schema from '#libs/schema/v2/mts';
+import { bearerAuth } from '#middlewares/passport';
+import rateLimiter from '#middlewares/rateLimiter';
+import validator from '#middlewares/validator';
+import mts from '#services/v2/mts/index';
+
+const route = Router();
+
+const routes = (app: Router) => {
+  app.use('/mts', bearerAuth, rateLimiter, route);
+
+  route.get(
+    '/contract/:contract/:token_id',
+    validator(schema.meta),
+    mts.metaData,
+  );
+};
+
+export default routes;

--- a/apps/api/src/services/v2/account/index.ts
+++ b/apps/api/src/services/v2/account/index.ts
@@ -1,0 +1,273 @@
+import { Response } from 'express';
+import { providers } from 'near-api-js';
+
+import { Network } from 'nb-types';
+
+import config from '#config';
+import catchAsync from '#libs/async';
+import { fetchMeta } from '#libs/fetchMeta';
+import { bytesParse, callFunction, getProvider } from '#libs/near';
+import sql from '#libs/postgres';
+import redis from '#libs/redis';
+import { Inventory } from '#libs/schema/v2/account';
+import { IntentsToken, RequestValidator, RPCResponse } from '#types/types';
+
+const EXPIRY = 60;
+const provider = getProvider();
+
+export const intentsTokens = async <T>(
+  provider: providers.JsonRpcProvider,
+  account: string,
+): Promise<T> => {
+  try {
+    return redis.cache(
+      `${account}:tokens`,
+      async () => {
+        const response: RPCResponse = await callFunction(
+          provider,
+          account,
+          'mt_tokens',
+          { account_id: account },
+        );
+        return bytesParse(response.result);
+      },
+      EXPIRY * 5,
+    );
+  } catch (error) {
+    return [] as T;
+  }
+};
+
+export const nftBalanceOf = async <T>(
+  provider: providers.JsonRpcProvider,
+  contract: string,
+  accountId: string,
+): Promise<null | T> => {
+  try {
+    return redis.cache(
+      `nft_balance:${contract}:${accountId}`,
+      async () => {
+        const response: RPCResponse = await callFunction(
+          provider,
+          contract,
+          'nft_balance_of',
+          { account_id: accountId },
+        );
+        return bytesParse(response.result);
+      },
+      EXPIRY,
+    );
+  } catch (error) {
+    return null;
+  }
+};
+
+export const mtBalances = async <T>(
+  provider: providers.JsonRpcProvider,
+  contractId: string,
+  accountId: string,
+  tokenIds: string[],
+): Promise<T> => {
+  try {
+    return redis.cache(
+      `mt:${contractId}:${accountId}:balances`,
+      async () => {
+        const response: RPCResponse = await callFunction(
+          provider,
+          contractId,
+          'mt_batch_balance_of',
+          { account_id: accountId, token_ids: tokenIds },
+        );
+
+        return bytesParse(response.result);
+      },
+      EXPIRY,
+    );
+  } catch (error) {
+    return [] as T;
+  }
+};
+
+export const ftsBalances = async (
+  provider: providers.JsonRpcProvider,
+  contract: string,
+  account: string,
+): Promise<string> => {
+  try {
+    const response: RPCResponse = await callFunction(
+      provider,
+      contract,
+      'ft_balance_of',
+      { account_id: account },
+    );
+    const parsed = bytesParse(response.result);
+    return parsed ?? '0';
+  } catch (error) {
+    return '0';
+  }
+};
+
+const inventory = catchAsync(
+  async (req: RequestValidator<Inventory>, res: Response) => {
+    const account = req.validator.data.account;
+
+    if (config.network !== Network.MAINNET) {
+      return res.status(200).json({ inventory: { intents: [], nfts: [] } });
+    }
+
+    const nep141 = 'nep141:';
+    const nep171 = 'nep171:';
+    const nep245 = 'nep245:';
+
+    const tokens = await intentsTokens<IntentsToken[]>(provider, account);
+
+    const tokenIds141 = tokens
+      .map((token) => token.token_id)
+      .filter((token) => token.startsWith(nep141));
+
+    const contractIds141 = tokenIds141.map((token) =>
+      token.replace(nep141, ''),
+    );
+
+    const tokenIds171 = tokens
+      .map((token) => token.token_id)
+      .filter((token) => token.startsWith(nep171));
+
+    const contractIds171 = tokenIds171.map(
+      (token) => token.replace(nep171, '').split(':')[0],
+    );
+
+    const tokenIds245 = tokens
+      .map((token) => token.token_id)
+      .filter((token) => token.startsWith(nep245));
+
+    const [balances141, metas141, metas171] = await Promise.all([
+      Promise.all(
+        contractIds141.map((contract) =>
+          ftsBalances(provider, contract, account).catch(() => {
+            return '0';
+          }),
+        ),
+      ),
+      contractIds141.length
+        ? sql`
+            SELECT
+              contract,
+              name,
+              symbol,
+              decimals,
+              icon,
+              reference,
+              price
+            FROM
+              ft_meta
+            WHERE
+              contract IN ${sql(contractIds141)}
+          `
+        : Promise.resolve([]),
+
+      contractIds171.length
+        ? sql`
+            SELECT
+              contract,
+              name,
+              symbol,
+              icon,
+              base_uri,
+              reference
+            FROM
+              nft_meta
+            WHERE
+              contract IN ${sql(contractIds171)}
+          `
+        : Promise.resolve([]),
+    ]);
+
+    const multitokens = await Promise.all(
+      tokenIds245.map(async (token) => {
+        const [contract, id] = token.replace(nep245, '').split(':');
+
+        const [meta, amount] = await Promise.all([
+          // Fetch metadata
+          (async () => {
+            try {
+              const metas = await fetchMeta(contract, id, EXPIRY);
+              return metas?.[0] ?? null;
+            } catch (error) {
+              return null;
+            }
+          })(),
+
+          // Fetch balance
+          (async () => {
+            try {
+              const balances = await mtBalances<string[]>(
+                provider,
+                contract,
+                account,
+                [id],
+              );
+              return balances?.[0] ?? '0';
+            } catch (error) {
+              return '0';
+            }
+          })(),
+        ]);
+
+        return {
+          amount,
+          contract,
+          meta,
+          token_id: token,
+        };
+      }),
+    );
+
+    return res.status(200).json({
+      inventory: {
+        fts: tokenIds141.map((token_id, index) => {
+          const contract = contractIds141[index];
+          const Metas141 = Array.isArray(metas141) ? metas141 : [];
+          const meta = Metas141.find((m) => m.contract === contract);
+          return {
+            amount: balances141[index] ?? '0',
+            contract,
+            meta: meta ?? null,
+            token_id,
+          };
+        }),
+        mts: multitokens,
+        nfts: await Promise.all(
+          contractIds171.map(async (contract) => {
+            const meta = metas171.find((m) => m.contract === contract);
+
+            let amount = '0';
+            try {
+              const balance = await nftBalanceOf<string>(
+                provider,
+                contract,
+                account,
+              );
+              amount = balance ?? '0';
+            } catch (error) {
+              return {
+                amount: '0',
+                contract,
+                meta: null,
+                token_id: `nep171:${contract}`,
+              };
+            }
+
+            return {
+              amount,
+              contract,
+              meta: meta ?? null,
+              token_id: `nep171:${contract}`,
+            };
+          }),
+        ),
+      },
+    });
+  },
+);
+export default { inventory };

--- a/apps/api/src/services/v2/mts/index.ts
+++ b/apps/api/src/services/v2/mts/index.ts
@@ -1,0 +1,22 @@
+import { Response } from 'express';
+
+import catchAsync from '#libs/async';
+import { fetchMeta } from '#libs/fetchMeta';
+import { RequestValidator } from '#types/types';
+
+type MetaRequest = {
+  contract: string;
+  token_id: string;
+};
+
+const metaData = catchAsync(
+  async (req: RequestValidator<MetaRequest>, res: Response) => {
+    const { contract, token_id } = req.validator.data;
+
+    const metas = await fetchMeta(contract, token_id);
+
+    return res.status(200).json(metas);
+  },
+);
+
+export default { metaData };

--- a/apps/api/src/types/types.ts
+++ b/apps/api/src/types/types.ts
@@ -126,3 +126,32 @@ export type Campaign = {
   url: string;
   user_id: number;
 };
+
+export type RPCResponse = {
+  block_hash: string;
+  block_height: number;
+  result: Uint8Array;
+};
+
+export type IntentsToken = {
+  token_id: string;
+};
+
+export type MtMetadata = {
+  base: {
+    decimals?: number;
+    icon?: string;
+    id: string;
+    name: string;
+    symbol: string;
+  };
+  token: {
+    description?: string;
+    extra?: string;
+    issued_at?: number;
+    media?: string;
+    starts_at?: number;
+    title?: string;
+    updated_at?: number;
+  };
+};


### PR DESCRIPTION
Adds a new inventory API to aggregate FT, MT, and NFT holdings per account, plus a dedicated multi-token metadata endpoint.
- Introduces RPCResponse, IntentsToken, and MtMetadata types.
- Implements /mts/contract/:contract/:token_id metadata route and /account/:account/inventory/mts inventory aggregation.
- Updates schemas and utils (bytesParse) to support the new endpoints and caching.