### PR TITLE
fix(app): update aurora explorer url to official domains

### DIFF
--- a/apps/app/src/hooks/app/useConfig.ts
+++ b/apps/app/src/hooks/app/useConfig.ts
@@ -79,8 +79,8 @@ export const useConfig = () => {
 
   const aurorablocksUrl =
     networkId === 'mainnet'
-      ? 'https://aurora.exploreblocks.io'
-      : 'https://aurora.exploreblocks.io';
+      ? 'https://explorer.mainnet.aurora.dev'
+      : 'https://explorer.testnet.aurora.dev';
 
   const verifierConfig: VerifierConfig[] =
     networkId === 'mainnet'

--- a/apps/app/src/utils/app/config.ts
+++ b/apps/app/src/utils/app/config.ts
@@ -34,8 +34,8 @@ export const docsUrl: string =
 
 export const aurorablocksUrl: string =
   networkId === 'mainnet'
-    ? 'https://aurora.exploreblocks.io'
-    : 'https://aurora.exploreblocks.io';
+    ? 'https://explorer.mainnet.aurora.dev'
+    : 'https://explorer.testnet.aurora.dev';
 
 export const verifierConfig =
   networkId === 'mainnet'


### PR DESCRIPTION
- Updated all Aurora Explorer links to use official domains:  
  - Testnet: `explorer.testnet.aurora.dev`  
  - Mainnet: `explorer.mainnet.aurora.dev`  
- Removed deprecated `exploreblocks.io` links