### PR TITLE
feat(app): add multi-token support

### DIFF
--- a/apps/app/src/app/[locale]/mt-token/[id]/layout.tsx
+++ b/apps/app/src/app/[locale]/mt-token/[id]/layout.tsx
@@ -1,0 +1,74 @@
+import { Metadata } from 'next';
+import { headers } from 'next/headers';
+
+import { getRequest } from '@/utils/app/api';
+import { appUrl } from '@/utils/app/config';
+import { MTTokenMeta } from '@/utils/types';
+
+const network = process.env.NEXT_PUBLIC_NETWORK_ID;
+
+export async function generateMetadata(props: {
+  params: Promise<{ id: string }>;
+  searchParams: Promise<{
+    a: string;
+  }>;
+}): Promise<Metadata> {
+  const params = await props.params;
+  const searchParams = await props.searchParams;
+
+  const { id } = params;
+  const contractAddress = searchParams?.a;
+
+  const headersList = await headers();
+  const host = headersList.get('host') || '';
+  const baseUrl = `https://${host}/`;
+
+  const tokenDetails = await getRequest(
+    `v2/mts/contract/${contractAddress}/${id}`,
+  );
+
+  const token: MTTokenMeta = tokenDetails?.contracts?.[0];
+
+  const title = `${network === 'testnet' ? 'TESTNET ' : ''}${
+    token ? `${token?.base?.name} (${token?.base?.symbol}) ` : ''
+  }Stats, Price, Holders & Transactions | NearBlocks`;
+
+  const description = token
+    ? `All ${token?.base?.name} (${token?.base?.symbol}) information in one place: Statistics, price, market-cap, total & circulating supply, number of holders & latest transactions`
+    : 'View detailed statistics, market cap, circulating supply, holders, and transaction data for the token on NearBlocks.';
+
+  const ogImageUrl = `${baseUrl}api/og?mtTokens&tokenHash=${id}&title=${encodeURIComponent(
+    title,
+  )}`;
+  return {
+    alternates: {
+      canonical: `${appUrl}/mt-token/${id}?a=${contractAddress}`,
+    },
+    description: description,
+    openGraph: {
+      description: description,
+      images: [
+        {
+          alt: title,
+          height: 405,
+          url: ogImageUrl.toString(),
+          width: 720,
+        },
+      ],
+      title: title,
+    },
+    title: title,
+  };
+}
+
+export default async function TokenLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return (
+    <div className="relative container-xxl mx-auto px-5">
+      <section>{children}</section>
+    </div>
+  );
+}

--- a/apps/app/src/app/[locale]/mt-token/[id]/page.tsx
+++ b/apps/app/src/app/[locale]/mt-token/[id]/page.tsx
@@ -1,0 +1,25 @@
+import { Suspense } from 'react';
+import { ErrorBoundary } from 'react-error-boundary';
+
+import Overview from '@/components/app/Tokens/MT/Overview';
+import MTTokenOverviewSkeleton from '@/components/app/skeleton/mt/MTTokenOverviewSkeleton';
+
+export default async function TokenIndex(props: {
+  params: Promise<{ id: string; locale: string }>;
+  searchParams: Promise<{
+    a: string;
+  }>;
+}) {
+  const searchParams = await props.searchParams;
+  const params = await props.params;
+
+  const { id } = params;
+
+  return (
+    <ErrorBoundary fallback={<MTTokenOverviewSkeleton error />}>
+      <Suspense fallback={<MTTokenOverviewSkeleton />}>
+        <Overview id={id} searchParams={searchParams} />
+      </Suspense>
+    </ErrorBoundary>
+  );
+}

--- a/apps/app/src/app/api/og/route.tsx
+++ b/apps/app/src/app/api/og/route.tsx
@@ -30,6 +30,7 @@ export async function GET(request: Request) {
   const blockHash = url.searchParams.has('blockHash');
   const token = url.searchParams.has('token');
   const nft = url.searchParams.has('nft');
+  const mtTokens = url.searchParams.has('mtTokens');
 
   const transaction = url.searchParams.has('transaction');
   const home = url.searchParams.has('home');
@@ -54,6 +55,8 @@ export async function GET(request: Request) {
   } else if (token) {
     svgString = thumbnailTokenSvg(brandConfig);
   } else if (nft) {
+    svgString = thumbnailTokenSvg(brandConfig);
+  } else if (mtTokens) {
     svgString = thumbnailTokenSvg(brandConfig);
   } else if (transaction) {
     svgString = thumbnailTransactionSvg(brandConfig);
@@ -85,6 +88,8 @@ export async function GET(request: Request) {
     titleText = `${brand.charAt(0).toUpperCase() + brand.slice(1)} Token`;
   } else if (nft && nftHash) {
     titleText = `${brand.charAt(0).toUpperCase() + brand.slice(1)} NFT Token`;
+  } else if (mtTokens && tokenHash) {
+    titleText = `${brand.charAt(0).toUpperCase() + brand.slice(1)} MT Token`;
   }
 
   return new ImageResponse(
@@ -230,6 +235,18 @@ export async function GET(request: Request) {
                 }}
               >
                 {truncateString(nftHash)}
+              </div>
+            )}
+
+            {mtTokens && tokenHash && (
+              <div
+                style={{
+                  fontSize: 40,
+                  fontWeight: 700,
+                  marginTop: '10px',
+                }}
+              >
+                {truncateString(tokenHash)}
               </div>
             )}
           </div>

--- a/apps/app/src/components/app/Address/AccountOverview.tsx
+++ b/apps/app/src/components/app/Address/AccountOverview.tsx
@@ -6,6 +6,7 @@ export default async function AccountOverview({ id }: any) {
   const statsData = getRequest('v1/stats');
   const tokenData = getRequest(`v1/fts/${id}`);
   const inventoryData = getRequest(`v1/account/${id}/inventory`);
+  const mtsData = getRequest(`v2/account/${id}/inventory/mts`);
   const syncData = getRequest(`v1/sync/status`);
   const spamList = getRequest(
     'https://raw.githubusercontent.com/Nearblocks/spam-token-list/main/tokens.json',
@@ -18,6 +19,7 @@ export default async function AccountOverview({ id }: any) {
     <AccountOverviewActions
       accountDataPromise={accountData}
       inventoryDataPromise={inventoryData}
+      mtsDataPromise={mtsData}
       spamTokensPromise={spamList}
       statsDataPromise={statsData}
       tokenDataPromise={tokenData}

--- a/apps/app/src/components/app/Address/AccountOverviewActions.tsx
+++ b/apps/app/src/components/app/Address/AccountOverviewActions.tsx
@@ -20,10 +20,12 @@ const AccountOverviewActions = ({
   spamTokensPromise,
   statsDataPromise,
   tokenDataPromise,
+  mtsDataPromise,
 }: {
   accountDataPromise: Promise<any>;
   inventoryDataPromise: Promise<any>;
   loading?: boolean;
+  mtsDataPromise: Promise<any>;
   spamTokensPromise: Promise<any>;
   statsDataPromise: Promise<any>;
   tokenDataPromise: Promise<any>;
@@ -34,6 +36,7 @@ const AccountOverviewActions = ({
   const token = use(tokenDataPromise);
   const inventory = use(inventoryDataPromise);
   const spam = use(spamTokensPromise);
+  const mtsData = use(mtsDataPromise);
   const accountData = account?.account?.[0];
   const statsData = stats?.stats?.[0];
   const tokenData = token?.contracts?.[0];
@@ -191,6 +194,7 @@ const AccountOverviewActions = ({
                 inventoryLoading={loading}
                 loading={loading}
                 spamTokens={spamTokens?.blacklist}
+                mtsData={mtsData}
               />
             </div>
           </div>

--- a/apps/app/src/components/app/Tokens/MT/Overview.tsx
+++ b/apps/app/src/components/app/Tokens/MT/Overview.tsx
@@ -1,0 +1,26 @@
+import { getRequest } from '@/utils/app/api';
+
+import OverviewActions from '@/components/app/Tokens/MT/OverviewActions';
+import { MTTokenMeta } from '@/utils/types';
+
+const Overview = async ({
+  id,
+  searchParams,
+}: {
+  id: string;
+  searchParams: { a: string };
+}) => {
+  const tokenResult = await getRequest(
+    `v2/mts/contract/${searchParams?.a}/${id}`,
+  );
+
+  const token: MTTokenMeta = tokenResult?.contracts?.[0];
+
+  return (
+    <>
+      <OverviewActions mtToken={token} />
+      <div className="py-6"></div>
+    </>
+  );
+};
+export default Overview;

--- a/apps/app/src/components/app/Tokens/MT/OverviewActions.tsx
+++ b/apps/app/src/components/app/Tokens/MT/OverviewActions.tsx
@@ -1,0 +1,185 @@
+'use client';
+
+import { getTimeAgoString } from '@/utils/libs';
+
+import TokenImage from '@/components/app/common/TokenImage';
+import Skeleton from '@/components/app/skeleton/common/Skeleton';
+import { CopyButton } from '@/components/app/common/CopyButton';
+import { shortenAddress } from '@/utils/app/libs';
+
+interface MTTokenBase {
+  name: string;
+  id: string;
+  symbol: string;
+  icon: string;
+  decimals: number;
+}
+
+interface MTTokenData {
+  title: string;
+  description: string;
+  media: string;
+  issued_at: number;
+  starts_at: number;
+  updated_at: number;
+  extra: string;
+}
+
+interface MTToken {
+  base: MTTokenBase;
+  token: MTTokenData;
+}
+
+interface Props {
+  mtToken: MTToken;
+}
+
+const MTOverviewActions = ({ mtToken }: Props) => {
+  const formatTimestamp = (timestamp: number) => {
+    return getTimeAgoString(timestamp * 1000);
+  };
+
+  return (
+    <>
+      <div className="flex items-center justify-between flex-wrap">
+        {!mtToken ? (
+          <div className="w-80 max-w-xs px-2 py-5">
+            <Skeleton className="h-7" />
+          </div>
+        ) : (
+          <div className="sm:flex flex-1 items-center w-full py-5 px-2">
+            <h1 className="break-all font-medium dark:text-neargray-10 text-nearblue-600 text-lg pr-2">
+              <span className="inline-flex align-middle h-7 w-7 -ml-1">
+                <TokenImage
+                  alt={mtToken?.base?.name}
+                  className="w-7 h-7"
+                  src={mtToken?.base?.icon}
+                />
+              </span>
+              <span className="inline-flex align-middle mx-2">MT Token:</span>
+              <span className="break-all align-middle font-semibold">
+                {mtToken?.base?.name}
+              </span>
+            </h1>
+          </div>
+        )}
+      </div>
+
+      <div>
+        <div className="grid grid-cols-1 lg:grid-cols-2 gap-4 mb-2 md:mb-2">
+          <div className="w-full">
+            <div className="h-full bg-white dark:bg-black-600 soft-shadow rounded-xl overflow-hidden">
+              <h2 className="border-b dark:border-black-200 p-3 text-nearblue-600 dark:text-neargray-10 text-sm font-semibold">
+                Overview
+              </h2>
+
+              <div className="px-3 divide-y dark:divide-black-200 text-sm text-nearblue-600 dark:text-neargray-10">
+                <div className="flex flex-wrap py-4">
+                  <div className="w-full md:w-1/4 mb-2 md:mb-0 ">Symbol:</div>
+                  {!mtToken ? (
+                    <div className="w-32">
+                      <Skeleton className="h-4" />
+                    </div>
+                  ) : (
+                    <div className="w-full md:w-3/4 break-words font-medium">
+                      {mtToken?.base?.symbol}
+                    </div>
+                  )}
+                </div>
+                <div className="flex flex-wrap py-4">
+                  <div className="w-full md:w-1/4 mb-2 md:mb-0 ">
+                    Description:
+                  </div>
+                  {!mtToken ? (
+                    <div className="w-32">
+                      <Skeleton className="h-4" />
+                    </div>
+                  ) : (
+                    <div className="w-full md:w-3/4 break-words">
+                      {mtToken?.token?.description ||
+                        'No description available'}
+                    </div>
+                  )}
+                </div>
+                <div className="flex flex-wrap py-4">
+                  <div className="w-full md:w-1/4 mb-2 md:mb-0 ">
+                    Issued At:
+                  </div>
+                  {!mtToken ? (
+                    <div className="w-32">
+                      <Skeleton className="h-4" />
+                    </div>
+                  ) : (
+                    <div className="w-full md:w-3/4 break-words">
+                      {formatTimestamp(mtToken?.token?.issued_at)}
+                    </div>
+                  )}
+                </div>
+                <div className="flex flex-wrap py-4">
+                  <div className="w-full md:w-1/4 mb-2 md:mb-0 ">
+                    Last Updated:
+                  </div>
+                  {!mtToken ? (
+                    <div className="w-32">
+                      <Skeleton className="h-4" />
+                    </div>
+                  ) : (
+                    <div className="w-full md:w-3/4 break-words">
+                      {formatTimestamp(mtToken?.token?.updated_at)}
+                    </div>
+                  )}
+                </div>
+              </div>
+            </div>
+          </div>
+
+          <div className="w-full">
+            <div className="h-full bg-white dark:bg-black-600 soft-shadow rounded-xl overflow-hidden">
+              <h2 className="border-b dark:border-black-200 p-3 text-nearblue-600 dark:text-neargray-10 text-sm font-semibold">
+                Profile Summary
+              </h2>
+              <div className="px-3 divide-y dark:divide-black-200 text-sm text-nearblue-600 dark:text-neargray-10">
+                <div className="flex xl:flex-nowrap md:!flex-nowrap sm:flex-nowrap flex-wrap items-center justify-between sm:divide-x sm:dark:divide-black-200 pt-4 pb-4 gap-y-2">
+                  <div className="flex md:items-center xl:gap-x-24 lg:gap-x-12 md:gap-x-28 mr-3 lg:flex-wrap xl:flex-nowrap md:!flex-nowrap sm:flex-wrap flex-wrap justify-between">
+                    <div className="w-full mb-1 md:mb-0">Token ID:</div>
+                    <div className=" items-center text-center flex lg:ml-[3px]">
+                      {!mtToken ? (
+                        <div className="w-full break-words">
+                          <div className="w-32">
+                            <Skeleton className="h-4" />
+                          </div>
+                        </div>
+                      ) : (
+                        <div className="w-full whitespace-nowrap flex">
+                          {shortenAddress(mtToken?.base?.id)}
+                          <span className="mx-0.5">
+                            <CopyButton textToCopy={mtToken?.base?.id} />
+                          </span>
+                        </div>
+                      )}
+                    </div>
+                  </div>
+                </div>
+
+                <div className="flex flex-wrap items-center justify-between py-4 w-full">
+                  <div className="w-full md:w-1/4 mb-2 md:mb-0 ">Decimals:</div>
+                  <div className="w-full md:w-3/4 break-words">
+                    {!mtToken ? (
+                      <div className="w-32">
+                        <Skeleton className="h-4" />
+                      </div>
+                    ) : (
+                      mtToken?.base?.decimals
+                    )}
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </>
+  );
+};
+
+export default MTOverviewActions;

--- a/apps/app/src/components/app/common/TokenInfo.tsx
+++ b/apps/app/src/components/app/common/TokenInfo.tsx
@@ -84,7 +84,11 @@ const TokenInfo = (props: TokenInfoProps) => {
     <>
       <span className="font-normal pl-1">{rpcAmount}</span>
       <Link
-        href={`/token/${contract}`}
+        href={
+          apiMeta?.tokenId
+            ? `/mt-token/${apiMeta?.tokenId}`
+            : `/token/${contract}`
+        }
         className="text-green flex items-center hover:no-underline dark:text-green-250 font-semibold"
       >
         <span className="flex items-center">

--- a/apps/app/src/components/app/skeleton/mt/MTTokenOverviewSkeleton.tsx
+++ b/apps/app/src/components/app/skeleton/mt/MTTokenOverviewSkeleton.tsx
@@ -1,0 +1,126 @@
+'use client';
+
+import React from 'react';
+
+import ErrorMessage from '@/components/app/common/ErrorMessage';
+import FaInbox from '@/components/app/Icons/FaInbox';
+import Skeleton from '@/components/app/skeleton/common/Skeleton';
+
+interface Props {
+  className?: string;
+  error?: boolean;
+  pageTab?: string;
+}
+
+const MTTokenOverviewSkeleton = ({ error }: Props) => {
+  return (
+    <>
+      <div className="flex items-center justify-between flex-wrap">
+        {!error ? (
+          <div className="w-80 max-w-xs px-2 py-5">
+            <Skeleton className="h-7" />
+          </div>
+        ) : (
+          <div className="w-80 max-w-xs py-4 bg-neargray-25 dark:bg-black-300">
+            {!error ? <Skeleton className="h-6 flex mt-2" /> : ''}
+          </div>
+        )}
+      </div>
+
+      <div>
+        {!error ? (
+          <div className="grid grid-cols-1 lg:grid-cols-2 gap-4 mb-2 md:mb-2">
+            <div className="w-full">
+              <div className="h-full bg-white dark:bg-black-600 soft-shadow rounded-xl overflow-hidden">
+                <h2 className="border-b dark:border-black-200 p-3 text-nearblue-600 dark:text-neargray-10 text-sm font-semibold">
+                  Overview
+                </h2>
+
+                <div className="px-3 divide-y dark:divide-black-200 text-sm text-nearblue-600 dark:text-neargray-10">
+                  <div className="flex flex-wrap py-4">
+                    <div className="w-full md:w-1/4 mb-2 md:mb-0 ">Symbol:</div>
+                    <div className="w-32">
+                      <Skeleton className="h-4" />
+                    </div>
+                  </div>
+                  <div className="flex flex-wrap py-4">
+                    <div className="w-full md:w-1/4 mb-2 md:mb-0 ">
+                      Description:
+                    </div>
+                    <div className="w-32">
+                      <Skeleton className="h-4" />
+                    </div>
+                  </div>
+                  <div className="flex flex-wrap py-4">
+                    <div className="w-full md:w-1/4 mb-2 md:mb-0 ">
+                      Issued At:
+                    </div>
+                    <div className="w-32">
+                      <Skeleton className="h-4" />
+                    </div>
+                  </div>
+                  <div className="flex flex-wrap py-4">
+                    <div className="w-full md:w-1/4 mb-2 md:mb-0 ">
+                      Last Updated:
+                    </div>
+                    <div className="w-32">
+                      <Skeleton className="h-4" />
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+
+            <div className="w-full">
+              <div className="h-full bg-white dark:bg-black-600 soft-shadow rounded-xl overflow-hidden">
+                <h2 className="border-b dark:border-black-200 p-3 text-nearblue-600 dark:text-neargray-10 text-sm font-semibold">
+                  Profile Summary
+                </h2>
+                <div className="px-3 divide-y dark:divide-black-200 text-sm text-nearblue-600 dark:text-neargray-10">
+                  <div className="flex xl:flex-nowrap md:!flex-nowrap sm:flex-nowrap flex-wrap items-center justify-between sm:divide-x sm:dark:divide-black-200 pt-4 pb-4 gap-y-2">
+                    <div className="flex md:items-center xl:gap-x-24 lg:gap-x-12 md:gap-x-28 mr-3 lg:flex-wrap xl:flex-nowrap md:!flex-nowrap sm:flex-wrap flex-wrap justify-between">
+                      <div className="w-full mb-1 md:mb-0">Token ID:</div>
+                      <div className=" items-center text-center flex lg:ml-[3px]">
+                        <div className="w-full break-words">
+                          <div className="w-32">
+                            <Skeleton className="h-4" />
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+
+                  <div className="flex flex-wrap items-center justify-between py-4 w-full">
+                    <div className="w-full md:w-1/4 mb-2 md:mb-0 ">
+                      Decimals:
+                    </div>
+                    <div className="w-full md:w-3/4 break-words">
+                      <div className="w-32">
+                        <Skeleton className="h-4" />
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        ) : (
+          <div className="w-full">
+            <div className="bg-white soft-shadow rounded-xl dark:bg-black-600">
+              <ErrorMessage
+                icons={<FaInbox />}
+                message={''}
+                mutedText="Please try again later"
+                reset
+              />
+            </div>
+          </div>
+        )}
+        <div className="py-6"></div>
+      </div>
+    </>
+  );
+};
+
+MTTokenOverviewSkeleton.displayName = 'Overview';
+export default MTTokenOverviewSkeleton;

--- a/apps/app/src/middleware.ts
+++ b/apps/app/src/middleware.ts
@@ -46,6 +46,7 @@ export const config = {
     '/([\\w-]+)?/address/(.+)',
     '/([\\w-]+)?/token/(.+)',
     '/([\\w-]+)?/nft-token/(.+)',
+    '/([\\w-]+)?/mt-token/(.+)',
     '/([\\w-]+)?/node-explorer/(.+)',
     '/([\\w-]+)?/apis/:path*',
   ],

--- a/apps/app/src/utils/app/actions.ts
+++ b/apps/app/src/utils/app/actions.ts
@@ -67,6 +67,7 @@ export async function handleFilterAndKeyword(
       receipts: [],
       txns: [],
       tokens: [],
+      mtTokens: [],
     };
 
     if (res?.blocks?.length) {
@@ -87,6 +88,10 @@ export async function handleFilterAndKeyword(
 
     if (res?.tokens?.length) {
       data.tokens = res.tokens;
+    }
+
+    if (res?.mtTokens?.length) {
+      data.mtTokens = res?.mtTokens;
     }
     const hasValidData = Object.values(data).some(
       (value) => Array.isArray(value) && value.length > 0,

--- a/apps/app/src/utils/app/rpc.ts
+++ b/apps/app/src/utils/app/rpc.ts
@@ -78,6 +78,7 @@ export const rpcSearch = async (keyword: string): Promise<SearchResponse> => {
     receipts: [],
     tokens: [],
     txns: [],
+    mtTokens: [],
   };
 
   const isQueryLong = keyword.length >= 43;

--- a/apps/app/src/utils/libs.ts
+++ b/apps/app/src/utils/libs.ts
@@ -699,3 +699,10 @@ export const parseEventJson = (log: string) => {
 
   return JSON.parse(jsonString);
 };
+
+export const constructTokenId = (
+  tokenId: string,
+  contractId: string,
+): string => {
+  return `${tokenId}?a=${contractId}`;
+};

--- a/apps/app/src/utils/types.ts
+++ b/apps/app/src/utils/types.ts
@@ -89,6 +89,7 @@ export type ApiMetaInfo = {
     symbol: string;
     volume24h: string;
     website: string;
+    tokenId?: string;
   };
 };
 
@@ -389,11 +390,13 @@ export type SearchResult = {
     receipt_id: string;
   }>;
   tokens: Array<{ contract: string }>;
+  mtTokens: Array<{ contract: string; token_id: string }>;
   txns?: Array<{ transaction_hash: string }>;
 };
 export type SearchRoute = {
   path?: string;
   type?: string;
+  rawPath?: string;
 };
 export type Debounce<TArgs extends any[]> = {
   (args: TArgs): void;
@@ -1926,6 +1929,7 @@ export type TokenMetadata = {
   description: string;
   website: string;
   icon: string | null;
+  tokenId?: string;
 };
 
 export type ProcessedTokenMeta = {
@@ -2101,4 +2105,87 @@ export type ReceiptAction = {
   receiptId: string;
   action_kind: string;
   args: Record<string, any>;
+};
+
+export type FTToken = {
+  amount: string;
+  contract: string;
+  meta: {
+    contract: string;
+    name: string;
+    symbol: string;
+    decimals: number;
+    icon: string | null;
+    reference: string | null;
+    price: string;
+  };
+  token_id: string;
+};
+
+export type MTToken = {
+  amount: string;
+  contract: string;
+  meta: {
+    base: {
+      name: string;
+      id: string;
+      symbol: string;
+      icon: string;
+      decimals: number;
+    };
+    token: {
+      title: string;
+      description: string;
+      media: string;
+      issued_at: number;
+      starts_at: number;
+      updated_at: number;
+      extra: string;
+    };
+  };
+  token_id: string;
+};
+
+export type NFTToken = {
+  amount: string;
+  contract: string;
+  meta: {
+    spec: string;
+    name: string;
+    symbol: string;
+    icon: string;
+    base_uri: string;
+    reference: string | null;
+    reference_hash: string | null;
+  };
+  token_id: string;
+};
+
+export type Inventory = {
+  fts: FTToken[];
+  mts: MTToken[];
+  nfts: NFTToken[];
+};
+
+export type mts = {
+  inventory: Inventory;
+};
+
+export type MTTokenMeta = {
+  base: {
+    name: string;
+    id: string;
+    symbol: string;
+    icon: string;
+    decimals: number;
+  };
+  token: {
+    title: string;
+    description: string;
+    media: string;
+    issued_at: number;
+    starts_at: number;
+    updated_at: number;
+    extra: string;
+  };
 };


### PR DESCRIPTION
- Integrate `v2/account/:account/inventory/mts` for the address page token inventory dropdown
- Add MT token detail page using `v2/mts/contract/:contract/:token_id`
- Support MT token responses in `/v1/search` results
- Display MT tokens in transaction actions via `v2/mts/contract/:contract/:token_id`