### PR TITLE
fix(app): temp filter duplicate eth.bridge.near contract from inventory

### DIFF
--- a/apps/app/src/components/app/Address/AccountOverviewActions.tsx
+++ b/apps/app/src/components/app/Address/AccountOverviewActions.tsx
@@ -57,7 +57,15 @@ const AccountOverviewActions = ({
 
   useEffect(() => {
     const loadBalances = async () => {
-      const fts = inventoryData?.fts;
+      // Temporary deduplication for eth.bridge.near contracts
+      // Remove after API v3 migration completes
+      const fts = inventoryData?.fts.filter(
+        (token: TokenListInfo) =>
+          !(
+            token?.ft_meta?.price === null &&
+            token?.contract === 'eth.bridge.near'
+          ),
+      );
       let total = Big(0);
       const tokens: TokenListInfo[] = [];
       const pricedTokens: TokenListInfo[] = [];


### PR DESCRIPTION
We've identified a temporary data duplication issue where the API now returns duplicate eth.bridge.near entries instead of removing Aurora contracts as intended. A permanent fix will be handled in v3 API. As an interim solution, we've added frontend filtering to remove duplicate eth.bridge.near entries from token displays.