### PR TITLE
fix(app): rpc fallback for txns with empty receipt tree

### DIFF
--- a/apps/app/src/components/app/Transactions/TxnsTabs.tsx
+++ b/apps/app/src/components/app/Transactions/TxnsTabs.tsx
@@ -23,8 +23,8 @@ export default async function TxnsTabs({
 
   let hasReceipts = true;
 
+  // TODO: temporary hack while we investigate missing local_receipts
   // Fallback to RPC when receipt_tree is null/empty
-  // This occurs when local_receipts data is missing
   if (isEmpty(receipt?.receipts?.[0]?.receipt_tree)) hasReceipts = false;
 
   const txn = data?.txns?.[0];


### PR DESCRIPTION
Fallback to RPC when receipt_tree is null due to missing local_receipts data