### PR TITLE
feat(indexer-receipts): add support for new local receipts

### DIFF
--- a/packages/nb-blocks-minio/src/type.ts
+++ b/packages/nb-blocks-minio/src/type.ts
@@ -50,6 +50,7 @@ export type Shard = {
 export type Chunk = {
   author: string;
   header: ChunkHeader;
+  localReceipts: Receipt[];
   receipts: Receipt[];
   transactions: IndexerTransactionWithOutcome[];
 };

--- a/packages/nb-blocks/src/type.ts
+++ b/packages/nb-blocks/src/type.ts
@@ -50,6 +50,7 @@ export type Shard = {
 export type Chunk = {
   author: string;
   header: ChunkHeader;
+  localReceipts: Receipt[];
   receipts: Receipt[];
   transactions: IndexerTransactionWithOutcome[];
 };

--- a/packages/nb-neardata/src/type.ts
+++ b/packages/nb-neardata/src/type.ts
@@ -96,6 +96,7 @@ export type Shard = {
 export type Chunk = {
   author: string;
   header: ChunkHeader;
+  localReceipts: Receipt[];
   receipts: Receipt[];
   transactions: IndexerTransactionWithOutcome[];
 };


### PR DESCRIPTION
Nearcore 2.10 introduced breaking changes: IndexerChunkView no longer contains local receipts as part of receipts field. A dedicated local_receipts is introduced instead