### PR TITLE
fix(app): show verified source code for deterministic/implicit accounts

### DIFF
--- a/apps/app/src/components/app/Address/Contract/OverviewActions.tsx
+++ b/apps/app/src/components/app/Address/Contract/OverviewActions.tsx
@@ -52,7 +52,8 @@ const OverviewActions = (props: Props) => {
   const deployments = use(deploymentsPromise);
   const sourceScanResponses = use(sourceScanDataPromise);
 
-  const accountId = account?.account?.[0]?.account_id;
+  const accountId =
+    account?.account?.[0]?.account_id || params?.id?.toLowerCase();
   const contractInfo: ContractParseInfo = parse?.contract?.[0]?.contract;
   const schema = parse?.contract?.[0]?.schema;
   const methodExist =


### PR DESCRIPTION
## Summary

Verified contract source code is not displayed for deterministic (`0s`-prefix) and implicit account IDs on the contract tab. The verification badge works, but no source files appear.

## Root cause

The `v1/account` API response for these accounts does not include an `account_id` field:

```
GET /v1/account/0sa8247564c6774a33b975a053fc4fbebbd869772d
→ { "account": [{ "amount": "...", "block_hash": "...", "block_height": "...", "locked": "0" }] }
   // no account_id!

GET /v1/account/sourcescan.near
→ { "account": [{ "account_id": "sourcescan.near", "amount": "...", ... }] }
   // has account_id ✓
```

This causes a chain of failures in `OverviewActions.tsx`:

1. `accountId = account?.account?.[0]?.account_id` → `undefined`
2. `if (accountId) fetchData()` → skipped, so `getContractMetadata()` never runs
3. `contractMetadata` stays `null`, so the correct `contract_path` (`"global-deployer"`) is never known
4. `VerifiedData` falls back to IPFS path `"src"` instead of `"global-deployer/src"`
5. IPFS returns empty structure → no source files displayed

## Fix

Fall back to `params.id.toLowerCase()` (the URL slug) when `account_id` is absent from the API response. `params.id` is always the correct account address since it comes directly from the URL the user is viewing.

## Verification

Tested the full data pipeline via API calls:

- `GET /v1/account/0sa824...` — account exists, but no `account_id` field
- `GET /v1/account/0sa824.../contract` — returns valid `code_base64` and `hash`
- `GET /v1/account/0sa824.../contract/parse` — detects `contract_source_metadata` in methods
- RPC `contract_source_metadata` on `0sa824...` — returns metadata with `contract_path: "global-deployer"`
- SourceScan `by-code-hash` API — returns valid CID for this code hash
- IPFS with `path=global-deployer/src` — returns `lib.rs`, `contract.rs`, `error.rs` ✓
- IPFS with `path=src` (the broken fallback) — returns empty structure ✗

## Related

Also submitted https://github.com/SourceScan/verifier-front/pull/4 to fix the same class of bug (hard-coded `.near`/`.testnet` TLD validation) on SourceScan's own frontend.

Originally reported in [this Slack thread](https://nearone.slack.com/archives/C0A64SAMDNG/p1773326314955379).