### PR TITLE
fix(indexer): destroy db pool before process exit across all indexers

### DIFF
--- a/apps/aggregates/src/index.ts
+++ b/apps/aggregates/src/index.ts
@@ -12,7 +12,8 @@ import { syncNFTHolders } from '#services/nft';
     logger.error('aborting...');
     logger.error(error);
     sentry.captureException(error);
-    process.exit();
+    await Promise.all([knex.destroy(), sentry.close(1_000)]);
+    process.exit(1);
   }
 })();
 

--- a/apps/indexer-accounts/src/index.ts
+++ b/apps/indexer-accounts/src/index.ts
@@ -17,7 +17,8 @@ import { syncData } from '#services/stream';
     logger.error('aborting...');
     logger.error(error);
     sentry.captureException(error);
-    process.exit();
+    await Promise.all([db.destroy(), sentry.close(1_000)]);
+    process.exit(1);
   }
 })();
 

--- a/apps/indexer-balance/src/index.ts
+++ b/apps/indexer-balance/src/index.ts
@@ -17,7 +17,8 @@ import { syncData } from '#services/stream';
     logger.error('aborting...');
     logger.error(error);
     sentry.captureException(error);
-    process.exit();
+    await Promise.all([db.destroy(), sentry.close(1_000)]);
+    process.exit(1);
   }
 })();
 

--- a/apps/indexer-base/src/index.ts
+++ b/apps/indexer-base/src/index.ts
@@ -17,7 +17,8 @@ import { syncData } from '#services/stream';
     logger.error('aborting...');
     logger.error(error);
     sentry.captureException(error);
-    process.exit();
+    await Promise.all([server.close(), db.destroy(), sentry.close(1_000)]);
+    process.exit(1);
   }
 })();
 

--- a/apps/indexer-contract/src/index.ts
+++ b/apps/indexer-contract/src/index.ts
@@ -15,7 +15,8 @@ import { syncData } from '#services/stream';
     logger.error('aborting...');
     logger.error(error);
     sentry.captureException(error);
-    process.exit();
+    await Promise.all([db.destroy(), sentry.close(1_000)]);
+    process.exit(1);
   }
 })();
 

--- a/apps/indexer-dex/src/index.ts
+++ b/apps/indexer-dex/src/index.ts
@@ -17,7 +17,12 @@ import { syncData } from '#services/stream';
     logger.error('aborting...');
     logger.error(error);
     sentry.captureException(error);
-    process.exit();
+    await Promise.all([
+      dbRead.destroy(),
+      dbWrite.destroy(),
+      sentry.close(1_000),
+    ]);
+    process.exit(1);
   }
 })();
 

--- a/apps/indexer-events/src/index.ts
+++ b/apps/indexer-events/src/index.ts
@@ -17,7 +17,8 @@ import { syncData } from '#services/stream';
     logger.error('aborting...');
     logger.error(error);
     sentry.captureException(error);
-    process.exit();
+    await Promise.all([db.destroy(), sentry.close(1_000)]);
+    process.exit(1);
   }
 })();
 

--- a/apps/indexer-multichain/src/index.ts
+++ b/apps/indexer-multichain/src/index.ts
@@ -16,7 +16,8 @@ import { syncData } from '#services/multichain';
     logger.error('aborting...');
     logger.error(error);
     sentry.captureException(error);
-    process.exit();
+    await Promise.all([db.destroy(), sentry.close(1_000)]);
+    process.exit(1);
   }
 })();
 

--- a/apps/indexer-multichain/src/libs/knex.ts
+++ b/apps/indexer-multichain/src/libs/knex.ts
@@ -21,7 +21,7 @@ const dbConfig = {
     connectionString: config.dbUrl,
     ssl: ssl?.ca ? ssl : false,
   },
-  pool: { max: 10, min: 1 },
+  pool: { max: 20, min: 1 },
 };
 
 export const db: Knex = createKnex(dbConfig);

--- a/apps/indexer-multichain/src/services/multichain.ts
+++ b/apps/indexer-multichain/src/services/multichain.ts
@@ -1,5 +1,6 @@
 import { logger } from 'nb-logger';
 
+import { db } from '#libs/knex';
 import Sentry from '#libs/sentry';
 import bitcoin from '#services/bitcoin';
 import evm from '#services/evm';
@@ -23,6 +24,7 @@ export const syncData = async () => {
   } catch (error) {
     logger.error(error);
     Sentry.captureException(error);
-    process.exit();
+    await Promise.all([db.destroy(), Sentry.close(1_000)]);
+    process.exit(1);
   }
 };

--- a/apps/indexer-receipts/src/index.ts
+++ b/apps/indexer-receipts/src/index.ts
@@ -18,7 +18,8 @@ import { syncData } from '#services/stream';
     logger.error('aborting...');
     logger.error(error);
     sentry.captureException(error);
-    process.exit();
+    await Promise.all([server.close(), db.destroy(), sentry.close(1_000)]);
+    process.exit(1);
   }
 })();
 

--- a/apps/indexer-signature/src/index.ts
+++ b/apps/indexer-signature/src/index.ts
@@ -15,7 +15,8 @@ import { syncData } from '#services/stream';
     logger.error('aborting...');
     logger.error(error);
     sentry.captureException(error);
-    process.exit();
+    await Promise.all([db.destroy(), sentry.close(1_000)]);
+    process.exit(1);
   }
 })();
 

--- a/apps/indexer-staking/src/index.ts
+++ b/apps/indexer-staking/src/index.ts
@@ -15,7 +15,8 @@ import { syncData } from '#services/stream';
     logger.error('aborting...');
     logger.error(error);
     sentry.captureException(error);
-    process.exit();
+    await Promise.all([db.destroy(), sentry.close(1_000)]);
+    process.exit(1);
   }
 })();
 


### PR DESCRIPTION
  - All indexers called `process.exit()` on crash without destroying the knex connection pool, leaving zombie connections in Postgres that accumulated across restarts (indexer-multichain reached 420+ connections
  from a pool max of 10)
  - Added `db.destroy()` before `process.exit()` in all indexers: base, receipts, accounts, balance, contract, dex, events, signature, staking, multichain, and aggregates
  - indexer-multichain: set `pool.max` to 20 and reduced `BATCH_SIZE` from 10 to 2 so concurrent queries (10 chains × 2) match the pool size, preventing `KnexTimeoutError` pool exhaustion
