### PR TITLE
fix(indexer-multichain/signature): enable tcp keepalive and tune pool limits

### DIFF
--- a/apps/indexer-multichain/src/index.ts
+++ b/apps/indexer-multichain/src/index.ts
@@ -33,3 +33,10 @@ const onSignal = async (signal: number | string) => {
 
 process.once('SIGINT', onSignal);
 process.once('SIGTERM', onSignal);
+process.once('unhandledRejection', async (error) => {
+  logger.error('unhandled rejection');
+  logger.error(error);
+  sentry.captureException(error);
+  await Promise.all([db.destroy(), sentry.close(1_000)]);
+  process.exit(1);
+});

--- a/apps/indexer-multichain/src/libs/knex.ts
+++ b/apps/indexer-multichain/src/libs/knex.ts
@@ -19,9 +19,16 @@ const dbConfig = {
   connection: {
     application_name: 'indexer-multichain',
     connectionString: config.dbUrl,
+    keepAlive: true,
+    keepAliveInitialDelayMillis: 10_000,
     ssl: ssl?.ca ? ssl : false,
   },
-  pool: { max: 20, min: 1 },
+  pool: {
+    max: 10,
+    min: 0,
+    idleTimeoutMillis: 30_000,
+    propagateCreateError: false,
+  },
 };
 
 export const db: Knex = createKnex(dbConfig);

--- a/apps/indexer-signature/src/index.ts
+++ b/apps/indexer-signature/src/index.ts
@@ -32,3 +32,10 @@ const onSignal = async (signal: number | string) => {
 
 process.once('SIGINT', onSignal);
 process.once('SIGTERM', onSignal);
+process.once('unhandledRejection', async (error) => {
+  logger.error('unhandled rejection');
+  logger.error(error);
+  sentry.captureException(error);
+  await Promise.all([db.destroy(), sentry.close(1_000)]);
+  process.exit(1);
+});

--- a/apps/indexer-signature/src/libs/knex.ts
+++ b/apps/indexer-signature/src/libs/knex.ts
@@ -19,9 +19,16 @@ const dbConfig = {
   connection: {
     application_name: 'indexer-signature',
     connectionString: config.dbUrl,
+    keepAlive: true,
+    keepAliveInitialDelayMillis: 10_000,
     ssl: ssl?.ca ? ssl : false,
   },
-  pool: { max: 10, min: 1 },
+  pool: {
+    max: 5,
+    min: 0,
+    idleTimeoutMillis: 30_000,
+    propagateCreateError: false,
+  },
 };
 
 const migrationConfig = {


### PR DESCRIPTION
## Summary

Fixes connection accumulation (up to 480) and reboot loops on multichain and signature indexers.

### Root cause
When indexer processes crash and get SIGKILL'd (OOM, Kubernetes force-kill after grace period), TCP keepalive is disabled by default — PostgreSQL server cannot detect dead clients, so zombie connections persist for hours. With signature restarting 60 times in 5h, leaked connections accumulate rapidly.

### Changes

**Pool configuration (both indexers):**
- Enable `keepAlive: true` with 10s initial delay so PostgreSQL detects dead clients in ~30s-2min instead of hours
- Lower pool max (multichain 20→10, signature 10→5) to reduce leaked connection footprint per crash cycle
- Set pool `min: 0` so idle connections are released instead of held forever
- Set `propagateCreateError: false` to survive transient connection creation failures (e.g. DB failover)
- Explicit `idleTimeoutMillis: 30_000` for clarity

**Unhandled rejection handler (both indexers):**
- Catch errors that bypass normal try/catch (e.g. remaining chain promises after `Promise.all` rejects) to ensure `db.destroy()` runs before exit
