### PR TITLE
fix: add type annotation to unhandledRejection error parameter

### DIFF
--- a/apps/indexer-multichain/src/index.ts
+++ b/apps/indexer-multichain/src/index.ts
@@ -33,7 +33,7 @@ const onSignal = async (signal: number | string) => {
 
 process.once('SIGINT', onSignal);
 process.once('SIGTERM', onSignal);
-process.once('unhandledRejection', async (error) => {
+process.once('unhandledRejection', async (error: unknown) => {
   logger.error('unhandled rejection');
   logger.error(error);
   sentry.captureException(error);

--- a/apps/indexer-signature/src/index.ts
+++ b/apps/indexer-signature/src/index.ts
@@ -32,7 +32,7 @@ const onSignal = async (signal: number | string) => {
 
 process.once('SIGINT', onSignal);
 process.once('SIGTERM', onSignal);
-process.once('unhandledRejection', async (error) => {
+process.once('unhandledRejection', async (error: unknown) => {
   logger.error('unhandled rejection');
   logger.error(error);
   sentry.captureException(error);


### PR DESCRIPTION
## Summary
- Fixes lint error from #1372 — adds `unknown` type annotation to `error` parameter in `unhandledRejection` handlers for both multichain and signature indexers