### PR TITLE
feat(api): restructure API docs with V3 primary, upgrade Scalar UI, restrict count endpoints

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Setup Node.js environment
         uses: actions/setup-node@v3
         with:
-          node-version: 20
+          node-version: 22
           cache: 'yarn'
 
       - name: Install dependencies

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -24,7 +24,7 @@
     "@opentelemetry/instrumentation-ioredis": "0.47.0",
     "@opentelemetry/instrumentation-pg": "0.50.0",
     "@opentelemetry/instrumentation-pino": "0.46.0",
-    "@scalar/express-api-reference": "0.4.173",
+    "@scalar/express-api-reference": "0.9.10",
     "@sentry/node": "7.119.0",
     "big.js": "6.2.1",
     "cors": "2.8.5",

--- a/apps/api/src/libs/apiDocumentation.ts
+++ b/apps/api/src/libs/apiDocumentation.ts
@@ -59,58 +59,155 @@ const apiDocumentation = async (app: Application, dir: string) => {
         { description: 'Testnet', url: config.testnetUrl },
       ],
       tags: [
+        // ── V3 (current) ──────────────────────────────────────────────
         {
-          description: `The "Account" endpoints provide access to various details about NEAR Protocol accounts, including account and contract information, deployment records, token inventories, access keys, and transaction histories. These endpoints also offer estimated counts for transactions, receipts, and balance changes, with support for pagination to efficiently manage large data sets.`,
-          name: 'Account',
-        },
-        {
-          description: `The "Blocks" endpoints allow retrieval of block information on the NEAR Protocol, including specific block details, the latest blocks, and blocks by pagination. They also provide an estimated total count of blocks, helping to manage and navigate the blockchain data efficiently.`,
-          name: 'Blocks',
+          description:
+            'Retrieve account details, balances, contract metadata, access keys, token holdings, and transaction history for any NEAR account.',
+          name: 'V3 / Accounts',
         },
         {
           description:
-            'The "Chain Abstraction" endpoints provide access to multichain data, including retrieving multichain accounts and transactions for a specific account. They support paginated queries for multichain transactions and offer estimated counts for multichain transactions, enabling comprehensive tracking.',
-          name: 'Chain Abstraction',
-        },
-        {
-          description: `The "Charts" endpoints offer chart data related to key blockchain statistics. These charts provide visual insights into the overall performance and metrics of the blockchain.`,
-          name: 'Charts',
-        },
-        {
-          description: `The "DEX" endpoints provide data on decentralized exchange pairs, including information on top pairs, transaction details, and charts. Fetches pair data and transaction history with pagination support, along with charts to visualize the trading activity.`,
-          name: 'DEX',
-        },
-        {
-          description: `The "FTs" endpoints provide data on fungible tokens, including the top tokens, transaction details, token holders, and more. They allow for pagination of token transactions and holders, and provide estimated counts for transactions and holders, along with token-specific information.`,
-          name: 'FTs',
-        },
-        {
-          description: 'Access keys related endpoints.',
-          name: 'Access Keys',
-        },
-        {
-          description: `The "Kitwallet" endpoints focus on account activities, staking pools, and related data. They provide access to staking deposits, account activities, call receivers, and likely tokens or NFTs for an account. Additionally, they offer details about account receipts, along with estimated counts.`,
-          name: 'Kitwallet',
-        },
-        {
-          description: `The "Legacy" endpoints provide information on the Near supply, including total and circulating supply, as well as the daily token burn rate.`,
-          name: 'Legacy',
-        },
-        {
-          description: `The "NFTs" endpoints provide detailed information about non-fungible tokens (NFTs), including top NFTs, transactions, holders, and token data. You can fetch NFT transactions and token info, along with paginated list and estimated counts for transactions, holders, and tokens.`,
-          name: 'NFTs',
+            'Query blocks by hash or height, list recent blocks, and retrieve 24-hour block production statistics.',
+          name: 'V3 / Blocks',
         },
         {
           description:
-            'The "Search" endpoints allow you to search for various blockchain entities, such as transactions, blocks, accounts, receipts, and tokens. You can search by specific identifiers like hash, block height, account ID, receipt ID, and token address.',
-          name: 'Search',
+            'Look up fungible token contracts, list top tokens, and paginate through transfer history and holder data.',
+          name: 'V3 / FTs',
         },
-        { description: 'Statistical data endpoints.', name: 'Stats' },
         {
-          description: `The "Transactions" endpoints provide access to transaction data. You can retrieve transactions by pagination, view the total estimated count, get the latest transactions, and fetch detailed information about specific transactions, including receipts and execution outcomes.`,
-          name: 'Txns',
+          description:
+            'Look up account information associated with a public access key.',
+          name: 'V3 / Keys',
         },
-        { description: 'Validator information endpoints.', name: 'Validators' },
+        {
+          description:
+            'Query chain-signature multichain transactions and daily signing statistics.',
+          name: 'V3 / Multichain',
+        },
+        {
+          description:
+            'Look up NFT contracts and individual tokens, list top collections, and paginate through transfer history and holder data.',
+          name: 'V3 / NFTs',
+        },
+        {
+          description:
+            'Search across transactions, blocks, accounts, receipts, and tokens by hash, height, ID, or address.',
+          name: 'V3 / Search',
+        },
+        {
+          description:
+            'Network-wide statistics including supply, gas usage, active accounts, and daily aggregates.',
+          name: 'V3 / Stats',
+        },
+        {
+          description:
+            'List and filter transactions, retrieve transaction details with receipts, and inspect associated token events.',
+          name: 'V3 / Txns',
+        },
+        // ── Legacy (v1/v2) — deprecated, will be removed ─────────────
+        {
+          description: 'Deprecated. These endpoints will be removed.',
+          name: 'Legacy / Account',
+        },
+        {
+          description: 'Deprecated. These endpoints will be removed.',
+          name: 'Legacy / Access Keys',
+        },
+        {
+          description: 'Deprecated. These endpoints will be removed.',
+          name: 'Legacy / Blocks',
+        },
+        {
+          description: 'Deprecated. These endpoints will be removed.',
+          name: 'Legacy / Chain Abstraction',
+        },
+        {
+          description: 'Deprecated. These endpoints will be removed.',
+          name: 'Legacy / Charts',
+        },
+        {
+          description: 'Deprecated. These endpoints will be removed.',
+          name: 'Legacy / DEX',
+        },
+        {
+          description: 'Deprecated. These endpoints will be removed.',
+          name: 'Legacy / FTs',
+        },
+        {
+          description: 'Deprecated. These endpoints will be removed.',
+          name: 'Legacy / Kitwallet',
+        },
+        {
+          description: 'Deprecated. These endpoints will be removed.',
+          name: 'Legacy / Supply',
+        },
+        {
+          description: 'Deprecated. These endpoints will be removed.',
+          name: 'Legacy / NFTs',
+        },
+        {
+          description: 'Deprecated. These endpoints will be removed.',
+          name: 'Legacy / Search',
+        },
+        {
+          description: 'Deprecated. These endpoints will be removed.',
+          name: 'Legacy / Stats',
+        },
+        {
+          description: 'Deprecated. These endpoints will be removed.',
+          name: 'Legacy / Txns',
+        },
+        {
+          description: 'Deprecated. These endpoints will be removed.',
+          name: 'Legacy / Validators',
+        },
+        {
+          description: 'Deprecated. These endpoints will be removed.',
+          name: 'Legacy / V2 Account',
+        },
+        {
+          description:
+            'V2 transaction endpoints. Use V3 / Txns for new integrations.',
+          name: 'Legacy / V2 Txns',
+        },
+      ],
+      'x-tagGroups': [
+        {
+          name: 'API',
+          tags: [
+            'V3 / Accounts',
+            'V3 / Blocks',
+            'V3 / FTs',
+            'V3 / Keys',
+            'V3 / Multichain',
+            'V3 / NFTs',
+            'V3 / Search',
+            'V3 / Stats',
+            'V3 / Txns',
+          ],
+        },
+        {
+          name: 'Legacy (Deprecated)',
+          tags: [
+            'Legacy / Account',
+            'Legacy / Access Keys',
+            'Legacy / Blocks',
+            'Legacy / Chain Abstraction',
+            'Legacy / Charts',
+            'Legacy / DEX',
+            'Legacy / FTs',
+            'Legacy / Kitwallet',
+            'Legacy / Supply',
+            'Legacy / NFTs',
+            'Legacy / Search',
+            'Legacy / Stats',
+            'Legacy / Txns',
+            'Legacy / Validators',
+            'Legacy / V2 Account',
+            'Legacy / V2 Txns',
+          ],
+        },
       ],
     },
   };
@@ -140,8 +237,8 @@ const apiDocumentation = async (app: Application, dir: string) => {
         }
           
       `,
+      documentDownloadType: 'none',
       favicon: 'https://nearblocks.io/favicon_32x32.png',
-      hideDownloadButton: true,
       layout: 'modern',
       metaData: {
         description:
@@ -154,10 +251,8 @@ const apiDocumentation = async (app: Application, dir: string) => {
           'NearBlocks REST API documentation for the NEAR Protocol. Provides endpoints to access blockchain data and integrate seamlessly with NEAR.',
         twitterTitle: 'Near(Ⓝ) REST API | NearBlocks',
       },
-      spec: {
-        url: '/openapi.json',
-      },
       theme: 'none',
+      url: '/openapi.json',
     }),
   );
 };

--- a/apps/api/src/middlewares/internalOnly.ts
+++ b/apps/api/src/middlewares/internalOnly.ts
@@ -1,0 +1,29 @@
+import { NextFunction, Request, Response } from 'express';
+
+import config from '#config';
+import { checkIPInSubnets } from '#middlewares/rateLimiter';
+
+// Exact counts on hypertables are expensive and unreliable at scale.
+// Restrict count endpoints to internal consumers only.
+const internalOnly = (req: Request, res: Response, next: NextFunction) => {
+  const authHeader = req.headers.authorization || '';
+  const token = authHeader.replace('Bearer ', '');
+
+  if (config.apiAccessKey && token === config.apiAccessKey) {
+    return next();
+  }
+
+  const reqIp = req.ip;
+  const ipAddress =
+    reqIp && reqIp.startsWith('::ffff:') ? reqIp.slice(7) : reqIp || '';
+
+  if (checkIPInSubnets(ipAddress)) {
+    return next();
+  }
+
+  return res.status(403).json({
+    message: 'This endpoint is currently unavailable.',
+  });
+};
+
+export default internalOnly;

--- a/apps/api/src/middlewares/rateLimiter.ts
+++ b/apps/api/src/middlewares/rateLimiter.ts
@@ -159,7 +159,7 @@ const rateLimiter = catchAsync(
   },
 );
 
-const checkIPInSubnets = (ipAddress: string): boolean => {
+export const checkIPInSubnets = (ipAddress: string): boolean => {
   for (const subnet of SUBNETS) {
     if (ip.cidrSubnet(subnet).contains(ipAddress)) {
       return true;

--- a/apps/api/src/routes/account.ts
+++ b/apps/api/src/routes/account.ts
@@ -23,7 +23,7 @@ const routes = (app: Router) => {
    *   get:
    *     summary: Get account info
    *     tags:
-   *       - Account
+   *       - Legacy / Account
    *     parameters:
    *       - in: path
    *         name: account
@@ -46,7 +46,7 @@ const routes = (app: Router) => {
    *   get:
    *     summary: Get contract info
    *     tags:
-   *       - Account
+   *       - Legacy / Account
    *     parameters:
    *       - in: path
    *         name: account
@@ -69,7 +69,7 @@ const routes = (app: Router) => {
    *   get:
    *     summary: Get contract deployment records (first & last)
    *     tags:
-   *       - Account
+   *       - Legacy / Account
    *     parameters:
    *       - in: path
    *         name: account
@@ -96,7 +96,7 @@ const routes = (app: Router) => {
    *   get:
    *     summary: Get parsed contract info
    *     tags:
-   *       - Account
+   *       - Legacy / Account
    *     parameters:
    *       - in: path
    *         name: account
@@ -123,7 +123,7 @@ const routes = (app: Router) => {
    *   get:
    *     summary: Get latest action args for contract method
    *     tags:
-   *       - Account
+   *       - Legacy / Account
    *     parameters:
    *       - in: path
    *         name: account
@@ -159,7 +159,7 @@ const routes = (app: Router) => {
    *   get:
    *     summary: Get account ft/nft token inventory
    *     tags:
-   *       - Account
+   *       - Legacy / Account
    *     parameters:
    *       - in: path
    *         name: account
@@ -186,7 +186,7 @@ const routes = (app: Router) => {
    *   get:
    *     summary: Get possible ft/nft token contracts
    *     tags:
-   *       - Account
+   *       - Legacy / Account
    *     parameters:
    *       - in: path
    *         name: account
@@ -209,7 +209,7 @@ const routes = (app: Router) => {
    *   get:
    *     summary: Get access keys by pagination
    *     tags:
-   *       - Account
+   *       - Legacy / Account
    *     parameters:
    *       - in: path
    *         name: account
@@ -255,7 +255,7 @@ const routes = (app: Router) => {
    *   get:
    *     summary: Get estimated access keys count
    *     tags:
-   *       - Account
+   *       - Legacy / Account
    *     parameters:
    *       - in: path
    *         name: account
@@ -283,7 +283,7 @@ const routes = (app: Router) => {
    *       - account/{account_id}/txns-only
    *       - account/{account_id}/receipts
    *     tags:
-   *       - Account
+   *       - Legacy / Account
    *     parameters:
    *       - in: path
    *         name: account
@@ -374,7 +374,7 @@ const routes = (app: Router) => {
    *   get:
    *     summary: Get estimated account txns count
    *     tags:
-   *       - Account
+   *       - Legacy / Account
    *     parameters:
    *       - in: path
    *         name: account
@@ -437,7 +437,7 @@ const routes = (app: Router) => {
    *   get:
    *     summary: Get account txns without receipts by pagination
    *     tags:
-   *       - Account
+   *       - Legacy / Account
    *     parameters:
    *       - in: path
    *         name: account
@@ -502,7 +502,7 @@ const routes = (app: Router) => {
    *   get:
    *     summary: Get estimated account txns without receipts count
    *     tags:
-   *       - Account
+   *       - Legacy / Account
    *     parameters:
    *       - in: path
    *         name: account
@@ -549,7 +549,7 @@ const routes = (app: Router) => {
    *   get:
    *     summary: Get account receipts by pagination
    *     tags:
-   *       - Account
+   *       - Legacy / Account
    *     parameters:
    *       - in: path
    *         name: account
@@ -622,7 +622,7 @@ const routes = (app: Router) => {
    *   get:
    *     summary: Get estimated account receipts count
    *     tags:
-   *       - Account
+   *       - Legacy / Account
    *     parameters:
    *       - in: path
    *         name: account
@@ -679,7 +679,7 @@ const routes = (app: Router) => {
    *   get:
    *     summary: Get account token txns by pagination
    *     tags:
-   *       - Account
+   *       - Legacy / Account
    *     parameters:
    *       - in: path
    *         name: account
@@ -757,7 +757,7 @@ const routes = (app: Router) => {
    *   get:
    *     summary: Get estimated account token txns count
    *     tags:
-   *       - Account
+   *       - Legacy / Account
    *     parameters:
    *       - in: path
    *         name: account
@@ -809,7 +809,7 @@ const routes = (app: Router) => {
    *   get:
    *     summary: Get account nft txns by pagination
    *     tags:
-   *       - Account
+   *       - Legacy / Account
    *     parameters:
    *       - in: path
    *         name: account
@@ -882,7 +882,7 @@ const routes = (app: Router) => {
    *   get:
    *     summary: Get estimated account nft txns count
    *     tags:
-   *       - Account
+   *       - Legacy / Account
    *     parameters:
    *       - in: path
    *         name: account
@@ -929,7 +929,7 @@ const routes = (app: Router) => {
    *   get:
    *     summary: Get account stake txns by pagination
    *     tags:
-   *       - Account
+   *       - Legacy / Account
    *     parameters:
    *       - in: path
    *         name: account
@@ -1000,7 +1000,7 @@ const routes = (app: Router) => {
    *   get:
    *     summary: Get estimated account stake txns count
    *     tags:
-   *       - Account
+   *       - Legacy / Account
    *     parameters:
    *       - in: path
    *         name: account
@@ -1047,7 +1047,7 @@ const routes = (app: Router) => {
    *   get:
    *     summary: Get account balance change activities by pagination
    *     tags:
-   *       - Account
+   *       - Legacy / Account
    *     parameters:
    *       - in: path
    *         name: account
@@ -1089,7 +1089,7 @@ const routes = (app: Router) => {
    *   get:
    *     summary: Get estimated account balance change activities count
    *     tags:
-   *       - Account
+   *       - Legacy / Account
    *     parameters:
    *       - in: path
    *         name: account

--- a/apps/api/src/routes/blocks.ts
+++ b/apps/api/src/routes/blocks.ts
@@ -17,7 +17,7 @@ const routes = (app: Router) => {
    *   get:
    *     summary: Get blocks by pagination
    *     tags:
-   *       - Blocks
+   *       - Legacy / Blocks
    *     parameters:
    *       - in: query
    *         name: cursor
@@ -52,7 +52,7 @@ const routes = (app: Router) => {
    *   get:
    *     summary: Get estimated total blocks count
    *     tags:
-   *       - Blocks
+   *       - Legacy / Blocks
    *     responses:
    *       200:
    *         description: Success response
@@ -65,7 +65,7 @@ const routes = (app: Router) => {
    *   get:
    *     summary: Get the latest blocks
    *     tags:
-   *       - Blocks
+   *       - Legacy / Blocks
    *     parameters:
    *       - in: query
    *         name: limit
@@ -87,7 +87,7 @@ const routes = (app: Router) => {
    *   get:
    *     summary: Get block info
    *     tags:
-   *       - Blocks
+   *       - Legacy / Blocks
    *     parameters:
    *       - in: path
    *         name: hash

--- a/apps/api/src/routes/chain-abstraction.ts
+++ b/apps/api/src/routes/chain-abstraction.ts
@@ -17,7 +17,7 @@ const routes = (app: Router) => {
    *   get:
    *     summary: Get multi chain accounts of an account
    *     tags:
-   *       - Chain Abstraction
+   *       - Legacy / Chain Abstraction
    *     parameters:
    *       - in: path
    *         name: account
@@ -44,7 +44,7 @@ const routes = (app: Router) => {
    *   get:
    *     summary: Get multi chain txns of the account by pagination
    *     tags:
-   *       - Chain Abstraction
+   *       - Legacy / Chain Abstraction
    *     parameters:
    *       - in: path
    *         name: account
@@ -134,7 +134,7 @@ const routes = (app: Router) => {
    *   get:
    *     summary: Get estimated multi chain txns count of the account
    *     tags:
-   *       - Chain Abstraction
+   *       - Legacy / Chain Abstraction
    *     parameters:
    *       - in: path
    *         name: account
@@ -196,7 +196,7 @@ const routes = (app: Router) => {
    *   get:
    *     summary: Get multi chain txns by pagination
    *     tags:
-   *       - Chain Abstraction
+   *       - Legacy / Chain Abstraction
    *     parameters:
    *       - in: query
    *         name: account
@@ -283,7 +283,7 @@ const routes = (app: Router) => {
    *   get:
    *     summary: Get estimated multi chain txns count
    *     tags:
-   *       - Chain Abstraction
+   *       - Legacy / Chain Abstraction
    *     parameters:
    *       - in: query
    *         name: account

--- a/apps/api/src/routes/charts.ts
+++ b/apps/api/src/routes/charts.ts
@@ -15,7 +15,7 @@ const routes = (app: Router) => {
    *   get:
    *     summary: Get charts data
    *     tags:
-   *       - Charts
+   *       - Legacy / Charts
    *     responses:
    *       200:
    *         description: Success response
@@ -28,7 +28,7 @@ const routes = (app: Router) => {
    *   get:
    *     summary: Get latest charts data
    *     tags:
-   *       - Charts
+   *       - Legacy / Charts
    *     responses:
    *       200:
    *         description: Success response
@@ -41,7 +41,7 @@ const routes = (app: Router) => {
    *   get:
    *     summary: Get txns per second by shards chart data
    *     tags:
-   *       - Charts
+   *       - Legacy / Charts
    *     responses:
    *       200:
    *         description: Success response

--- a/apps/api/src/routes/dex.ts
+++ b/apps/api/src/routes/dex.ts
@@ -18,7 +18,7 @@ const routes = (app: Router) => {
    *   get:
    *     summary: Get top dex pairs by pagination
    *     tags:
-   *       - DEX
+   *       - Legacy / DEX
    *     parameters:
    *       - in: query
    *         name: search
@@ -67,7 +67,7 @@ const routes = (app: Router) => {
    *   get:
    *     summary: Get top dex pairs count
    *     tags:
-   *       - DEX
+   *       - Legacy / DEX
    *     parameters:
    *       - in: query
    *         name: search
@@ -86,7 +86,7 @@ const routes = (app: Router) => {
    *   get:
    *     summary: Get dex pair info
    *     tags:
-   *       - DEX
+   *       - Legacy / DEX
    *     parameters:
    *       - in: path
    *         name: pair
@@ -109,7 +109,7 @@ const routes = (app: Router) => {
    *   get:
    *     summary: Get dex pair txns by pagination
    *     tags:
-   *       - DEX
+   *       - Legacy / DEX
    *     parameters:
    *       - in: path
    *         name: pair
@@ -150,7 +150,7 @@ const routes = (app: Router) => {
    *   get:
    *     summary: Get dex pair txns count
    *     tags:
-   *       - DEX
+   *       - Legacy / DEX
    *     parameters:
    *       - in: path
    *         name: pair
@@ -178,7 +178,7 @@ const routes = (app: Router) => {
    *   get:
    *     summary: Get dex pair chart data
    *     tags:
-   *       - DEX
+   *       - Legacy / DEX
    *     parameters:
    *       - in: path
    *         name: pair

--- a/apps/api/src/routes/fts.ts
+++ b/apps/api/src/routes/fts.ts
@@ -18,7 +18,7 @@ const routes = (app: Router) => {
    *   get:
    *     summary: Get top tokens by pagination
    *     tags:
-   *       - FTs
+   *       - Legacy / FTs
    *     parameters:
    *       - in: query
    *         name: search
@@ -67,7 +67,7 @@ const routes = (app: Router) => {
    *   get:
    *     summary: Get top tokens count
    *     tags:
-   *       - FTs
+   *       - Legacy / FTs
    *     parameters:
    *       - in: query
    *         name: search
@@ -86,7 +86,7 @@ const routes = (app: Router) => {
    *   get:
    *     summary: Get token txns by pagination
    *     tags:
-   *       - FTs
+   *       - Legacy / FTs
    *     parameters:
    *       - in: query
    *         name: cursor
@@ -123,7 +123,7 @@ const routes = (app: Router) => {
    *   get:
    *     summary: Get estimated token txns count
    *     tags:
-   *       - FTs
+   *       - Legacy / FTs
    *     responses:
    *       200:
    *         description: Success response
@@ -136,7 +136,7 @@ const routes = (app: Router) => {
    *   get:
    *     summary: Get token info
    *     tags:
-   *       - FTs
+   *       - Legacy / FTs
    *     parameters:
    *       - in: path
    *         name: contract
@@ -159,7 +159,7 @@ const routes = (app: Router) => {
    *   get:
    *     summary: Get token txns by pagination
    *     tags:
-   *       - FTs
+   *       - Legacy / FTs
    *     parameters:
    *       - in: path
    *         name: contract
@@ -223,7 +223,7 @@ const routes = (app: Router) => {
    *   get:
    *     summary: Get estimated token txns count
    *     tags:
-   *       - FTs
+   *       - Legacy / FTs
    *     parameters:
    *       - in: path
    *         name: contract
@@ -261,7 +261,7 @@ const routes = (app: Router) => {
    *   get:
    *     summary: Get token holders by pagination
    *     tags:
-   *       - FTs
+   *       - Legacy / FTs
    *     parameters:
    *       - in: path
    *         name: contract
@@ -307,7 +307,7 @@ const routes = (app: Router) => {
    *   get:
    *     summary: Get estimated token holders count
    *     tags:
-   *       - FTs
+   *       - Legacy / FTs
    *     parameters:
    *       - in: path
    *         name: contract

--- a/apps/api/src/routes/keys.ts
+++ b/apps/api/src/routes/keys.ts
@@ -17,7 +17,7 @@ const routes = (app: Router) => {
    *   get:
    *     summary: Get access key info by public key
    *     tags:
-   *       - Access Keys
+   *       - Legacy / Access Keys
    *     parameters:
    *       - in: path
    *         name: key

--- a/apps/api/src/routes/kitwallet.ts
+++ b/apps/api/src/routes/kitwallet.ts
@@ -19,7 +19,7 @@ const routes = (app: Router) => {
    *   get:
    *     summary: Get all staking pools
    *     tags:
-   *       - Kitwallet
+   *       - Legacy / Kitwallet
    *     responses:
    *       200:
    *         description: Success response
@@ -32,7 +32,7 @@ const routes = (app: Router) => {
    *   get:
    *     summary: Get staking deposits for an account
    *     tags:
-   *       - Kitwallet
+   *       - Legacy / Kitwallet
    *     parameters:
    *       - in: path
    *         name: account
@@ -59,7 +59,7 @@ const routes = (app: Router) => {
    *   get:
    *     summary: Get accounts by public key
    *     tags:
-   *       - Kitwallet
+   *       - Legacy / Kitwallet
    *     parameters:
    *       - in: path
    *         name: key
@@ -86,7 +86,7 @@ const routes = (app: Router) => {
    *   get:
    *     summary: Get activities for an account
    *     tags:
-   *       - Kitwallet
+   *       - Legacy / Kitwallet
    *     parameters:
    *       - in: path
    *         name: account
@@ -113,7 +113,7 @@ const routes = (app: Router) => {
    *   get:
    *     summary: Get call receivers for an account
    *     tags:
-   *       - Kitwallet
+   *       - Legacy / Kitwallet
    *     parameters:
    *       - in: path
    *         name: account
@@ -140,7 +140,7 @@ const routes = (app: Router) => {
    *   get:
    *     summary: Get likely tokens for an account
    *     tags:
-   *       - Kitwallet
+   *       - Legacy / Kitwallet
    *     parameters:
    *       - in: path
    *         name: account
@@ -167,7 +167,7 @@ const routes = (app: Router) => {
    *   get:
    *     summary: Get likely tokens for an account from block
    *     tags:
-   *       - Kitwallet
+   *       - Legacy / Kitwallet
    *     parameters:
    *       - in: path
    *         name: account
@@ -199,7 +199,7 @@ const routes = (app: Router) => {
    *   get:
    *     summary: Get likely NFTs for an account
    *     tags:
-   *       - Kitwallet
+   *       - Legacy / Kitwallet
    *     parameters:
    *       - in: path
    *         name: account
@@ -226,7 +226,7 @@ const routes = (app: Router) => {
    *   get:
    *     summary: Get likely NFTs for an account from block
    *     tags:
-   *       - Kitwallet
+   *       - Legacy / Kitwallet
    *     parameters:
    *       - in: path
    *         name: account
@@ -258,7 +258,7 @@ const routes = (app: Router) => {
    *   get:
    *     summary: Get account receipts
    *     tags:
-   *       - Kitwallet
+   *       - Legacy / Kitwallet
    *     parameters:
    *       - in: path
    *         name: account
@@ -335,7 +335,7 @@ const routes = (app: Router) => {
    *   get:
    *     summary: Get estimated account receipts count
    *     tags:
-   *       - Kitwallet
+   *       - Legacy / Kitwallet
    *     parameters:
    *       - in: path
    *         name: account

--- a/apps/api/src/routes/legacy.ts
+++ b/apps/api/src/routes/legacy.ts
@@ -17,7 +17,7 @@ const routes = (app: Router) => {
    *   get:
    *     summary: Get total near supply
    *     tags:
-   *       - Legacy
+   *       - Legacy / Supply
    *     parameters:
    *       - in: query
    *         name: unit
@@ -45,7 +45,7 @@ const routes = (app: Router) => {
    *   get:
    *     summary: Get circulating near supply
    *     tags:
-   *       - Legacy
+   *       - Legacy / Supply
    *     parameters:
    *       - in: query
    *         name: unit
@@ -73,7 +73,7 @@ const routes = (app: Router) => {
    *   get:
    *     summary: Get tokens burnt per day
    *     tags:
-   *       - Legacy
+   *       - Legacy / Supply
    *     parameters:
    *       - in: query
    *         name: period

--- a/apps/api/src/routes/nfts.ts
+++ b/apps/api/src/routes/nfts.ts
@@ -19,7 +19,7 @@ const routes = (app: Router) => {
    *   get:
    *     summary: Get top NFTs by pagination
    *     tags:
-   *       - NFTs
+   *       - Legacy / NFTs
    *     parameters:
    *       - in: query
    *         name: search
@@ -68,7 +68,7 @@ const routes = (app: Router) => {
    *   get:
    *     summary: Get top NFTs count
    *     tags:
-   *       - NFTs
+   *       - Legacy / NFTs
    *     parameters:
    *       - in: query
    *         name: search
@@ -87,7 +87,7 @@ const routes = (app: Router) => {
    *   get:
    *     summary: Get NFT transactions by pagination
    *     tags:
-   *       - NFTs
+   *       - Legacy / NFTs
    *     parameters:
    *       - in: query
    *         name: cursor
@@ -124,7 +124,7 @@ const routes = (app: Router) => {
    *   get:
    *     summary: Get estimated NFT transactions count
    *     tags:
-   *       - NFTs
+   *       - Legacy / NFTs
    *     responses:
    *       200:
    *         description: Success response
@@ -137,7 +137,7 @@ const routes = (app: Router) => {
    *   get:
    *     summary: Get NFT info
    *     tags:
-   *       - NFTs
+   *       - Legacy / NFTs
    *     parameters:
    *       - in: path
    *         name: contract
@@ -160,7 +160,7 @@ const routes = (app: Router) => {
    *   get:
    *     summary: Get NFT transactions by pagination
    *     tags:
-   *       - NFTs
+   *       - Legacy / NFTs
    *     parameters:
    *       - in: path
    *         name: contract
@@ -224,7 +224,7 @@ const routes = (app: Router) => {
    *   get:
    *     summary: Get estimated NFT transaction count
    *     tags:
-   *       - NFTs
+   *       - Legacy / NFTs
    *     parameters:
    *       - in: path
    *         name: contract
@@ -262,7 +262,7 @@ const routes = (app: Router) => {
    *   get:
    *     summary: Get NFT holders by pagination
    *     tags:
-   *       - NFTs
+   *       - Legacy / NFTs
    *     parameters:
    *       - in: path
    *         name: contract
@@ -308,7 +308,7 @@ const routes = (app: Router) => {
    *   get:
    *     summary: Get estimated NFT holders count
    *     tags:
-   *       - NFTs
+   *       - Legacy / NFTs
    *     parameters:
    *       - in: path
    *         name: contract
@@ -335,7 +335,7 @@ const routes = (app: Router) => {
    *   get:
    *     summary: Get NFT tokens list by pagination
    *     tags:
-   *       - NFTs
+   *       - Legacy / NFTs
    *     parameters:
    *       - in: path
    *         name: contract
@@ -374,7 +374,7 @@ const routes = (app: Router) => {
    *   get:
    *     summary: Get estimated NFT tokens count
    *     tags:
-   *       - NFTs
+   *       - Legacy / NFTs
    *     parameters:
    *       - in: path
    *         name: contract
@@ -401,7 +401,7 @@ const routes = (app: Router) => {
    *   get:
    *     summary: Get NFT token info
    *     tags:
-   *       - NFTs
+   *       - Legacy / NFTs
    *     parameters:
    *       - in: path
    *         name: contract
@@ -437,7 +437,7 @@ const routes = (app: Router) => {
    *   get:
    *     summary: Get NFT token transactions by pagination
    *     tags:
-   *       - NFTs
+   *       - Legacy / NFTs
    *     parameters:
    *       - in: path
    *         name: contract
@@ -509,7 +509,7 @@ const routes = (app: Router) => {
    *   get:
    *     summary: Get estimated NFT token transactions count
    *     tags:
-   *       - NFTs
+   *       - Legacy / NFTs
    *     parameters:
    *       - in: path
    *         name: contract

--- a/apps/api/src/routes/search.ts
+++ b/apps/api/src/routes/search.ts
@@ -17,7 +17,7 @@ const routes = (app: Router) => {
    *   get:
    *     summary: Search txn by hash, block by height/hash, account by id, receipt by id, tokens by hex address
    *     tags:
-   *       - Search
+   *       - Legacy / Search
    *     parameters:
    *       - in: query
    *         name: keyword
@@ -37,7 +37,7 @@ const routes = (app: Router) => {
    *   get:
    *     summary: Search txns by hash
    *     tags:
-   *       - Search
+   *       - Legacy / Search
    *     parameters:
    *       - in: query
    *         name: keyword
@@ -57,7 +57,7 @@ const routes = (app: Router) => {
    *   get:
    *     summary: Search blocks by hash/height
    *     tags:
-   *       - Search
+   *       - Legacy / Search
    *     parameters:
    *       - in: query
    *         name: keyword
@@ -80,7 +80,7 @@ const routes = (app: Router) => {
    *   get:
    *     summary: Search accounts by id
    *     tags:
-   *       - Search
+   *       - Legacy / Search
    *     parameters:
    *       - in: query
    *         name: keyword
@@ -100,7 +100,7 @@ const routes = (app: Router) => {
    *   get:
    *     summary: Search receipts by id
    *     tags:
-   *       - Search
+   *       - Legacy / Search
    *     parameters:
    *       - in: query
    *         name: keyword
@@ -120,7 +120,7 @@ const routes = (app: Router) => {
    *   get:
    *     summary: Search tokens by hex address
    *     tags:
-   *       - Search
+   *       - Legacy / Search
    *     parameters:
    *       - in: query
    *         name: keyword

--- a/apps/api/src/routes/stats.ts
+++ b/apps/api/src/routes/stats.ts
@@ -17,7 +17,7 @@ const routes = (app: Router) => {
    *   get:
    *     summary: Get stats
    *     tags:
-   *       - Stats
+   *       - Legacy / Stats
    *     responses:
    *       200:
    *         description: Success response
@@ -30,7 +30,7 @@ const routes = (app: Router) => {
    *   get:
    *     summary: Get near price
    *     tags:
-   *       - Stats
+   *       - Legacy / Stats
    *     parameters:
    *       - in: query
    *         name: date

--- a/apps/api/src/routes/txns.ts
+++ b/apps/api/src/routes/txns.ts
@@ -17,7 +17,7 @@ const routes = (app: Router) => {
    *   get:
    *     summary: Get txns by pagination
    *     tags:
-   *       - Txns
+   *       - Legacy / Txns
    *     parameters:
    *       - in: query
    *         name: block
@@ -94,7 +94,7 @@ const routes = (app: Router) => {
    *   get:
    *     summary: Get estimated total txns count
    *     tags:
-   *       - Txns
+   *       - Legacy / Txns
    *     parameters:
    *       - in: query
    *         name: block
@@ -143,7 +143,7 @@ const routes = (app: Router) => {
    *   get:
    *     summary: Get the latest txns
    *     tags:
-   *       - Txns
+   *       - Legacy / Txns
    *     parameters:
    *       - in: query
    *         name: limit
@@ -165,7 +165,7 @@ const routes = (app: Router) => {
    *   get:
    *     summary: Get txn info
    *     tags:
-   *       - Txns
+   *       - Legacy / Txns
    *     parameters:
    *       - in: path
    *         name: hash
@@ -188,7 +188,7 @@ const routes = (app: Router) => {
    *   get:
    *     summary: Get txn info with receipts and execution outcomes
    *     tags:
-   *       - Txns
+   *       - Legacy / Txns
    *     parameters:
    *       - in: path
    *         name: hash

--- a/apps/api/src/routes/v2/account.ts
+++ b/apps/api/src/routes/v2/account.ts
@@ -18,7 +18,7 @@ const routes = (app: Router) => {
    *   get:
    *     summary: Get account receipts by pagination
    *     tags:
-   *       - Account
+   *       - Legacy / V2 Account
    *     parameters:
    *       - in: path
    *         name: account
@@ -95,7 +95,7 @@ const routes = (app: Router) => {
    *   get:
    *     summary: Get estimated account receipts count
    *     tags:
-   *       - Account
+   *       - Legacy / V2 Account
    *     parameters:
    *       - in: path
    *         name: account

--- a/apps/api/src/routes/v2/txns.ts
+++ b/apps/api/src/routes/v2/txns.ts
@@ -17,7 +17,7 @@ const routes = (app: Router) => {
    *   get:
    *     summary: Get txn info with receipts and execution outcomes
    *     tags:
-   *       - Txns
+   *       - Legacy / V2 Txns
    *     parameters:
    *       - in: path
    *         name: hash
@@ -40,7 +40,7 @@ const routes = (app: Router) => {
    *   get:
    *     summary: Get txn receipts
    *     tags:
-   *       - Txns
+   *       - Legacy / V2 Txns
    *     parameters:
    *       - in: path
    *         name: hash

--- a/apps/api/src/routes/v3/accounts/account.ts
+++ b/apps/api/src/routes/v3/accounts/account.ts
@@ -10,7 +10,7 @@ const routes = (route: Router) => {
    * @openapi
    * /v3/accounts/{account}:
    *   get:
-   *     summary: Get account info
+   *     summary: Get account details
    *     tags:
    *       - V3 / Accounts
    *     parameters:

--- a/apps/api/src/routes/v3/accounts/assets.ts
+++ b/apps/api/src/routes/v3/accounts/assets.ts
@@ -2,6 +2,7 @@ import { Router } from 'express';
 
 import request from 'nb-schemas/dist/accounts/assets/request.js';
 
+import internalOnly from '#middlewares/internalOnly';
 import { validate } from '#middlewares/validate';
 import service from '#services/v3/accounts/assets';
 
@@ -10,7 +11,7 @@ const routes = (route: Router) => {
    * @openapi
    * /v3/accounts/{account}/assets/fts:
    *   get:
-   *     summary: Get account ft assets
+   *     summary: List account FT balances
    *     tags:
    *       - V3 / Accounts
    *     parameters:
@@ -48,7 +49,8 @@ const routes = (route: Router) => {
    * @openapi
    * /v3/accounts/{account}/assets/fts/count:
    *   get:
-   *     summary: Get account ft assets count
+   *     summary: Get account FT balances count
+   *     x-internal: true
    *     tags:
    *       - V3 / Accounts
    *     parameters:
@@ -64,6 +66,7 @@ const routes = (route: Router) => {
    */
   route.get(
     '/:account/assets/fts/count',
+    internalOnly,
     validate(request.ftCount),
     service.ftCount,
   );
@@ -72,7 +75,7 @@ const routes = (route: Router) => {
    * @openapi
    * /v3/accounts/{account}/assets/nfts:
    *   get:
-   *     summary: Get account nft assets
+   *     summary: List account NFT balances
    *     tags:
    *       - V3 / Accounts
    *     parameters:
@@ -110,7 +113,8 @@ const routes = (route: Router) => {
    * @openapi
    * /v3/accounts/{account}/assets/nfts/count:
    *   get:
-   *     summary: Get account nft assets count
+   *     summary: Get account NFT balances count
+   *     x-internal: true
    *     tags:
    *       - V3 / Accounts
    *     parameters:
@@ -126,6 +130,7 @@ const routes = (route: Router) => {
    */
   route.get(
     '/:account/assets/nfts/count',
+    internalOnly,
     validate(request.nftCount),
     service.nftCount,
   );

--- a/apps/api/src/routes/v3/accounts/contract.ts
+++ b/apps/api/src/routes/v3/accounts/contract.ts
@@ -10,7 +10,7 @@ const routes = (route: Router) => {
    * @openapi
    * /v3/accounts/{account}/contract:
    *   get:
-   *     summary: Get contract info
+   *     summary: Get contract metadata
    *     tags:
    *       - V3 / Accounts
    *     parameters:
@@ -34,7 +34,7 @@ const routes = (route: Router) => {
    * @openapi
    * /v3/accounts/{account}/contract/deployments:
    *   get:
-   *     summary: Get contract deployments (first & last)
+   *     summary: Get contract deployment history
    *     tags:
    *       - V3 / Accounts
    *     parameters:
@@ -58,7 +58,7 @@ const routes = (route: Router) => {
    * @openapi
    * /v3/accounts/{account}/contract/schema:
    *   get:
-   *     summary: Get contract abi schema
+   *     summary: Get contract ABI schema
    *     tags:
    *       - V3 / Accounts
    *     parameters:
@@ -82,7 +82,7 @@ const routes = (route: Router) => {
    * @openapi
    * /v3/accounts/{account}/contract/{method}/action:
    *   get:
-   *     summary: Get latest action args for method
+   *     summary: Get latest action args for a contract method
    *     tags:
    *       - V3 / Accounts
    *     parameters:

--- a/apps/api/src/routes/v3/accounts/fts.ts
+++ b/apps/api/src/routes/v3/accounts/fts.ts
@@ -2,6 +2,7 @@ import { Router } from 'express';
 
 import request from 'nb-schemas/dist/accounts/fts/request.js';
 
+import internalOnly from '#middlewares/internalOnly';
 import { validate } from '#middlewares/validate';
 import service from '#services/v3/accounts/fts';
 
@@ -10,7 +11,7 @@ const routes = (route: Router) => {
    * @openapi
    * /v3/accounts/{account}/ft-txns:
    *   get:
-   *     summary: Get account ft txns
+   *     summary: List account FT transfers
    *     tags:
    *       - V3 / Accounts
    *     parameters:
@@ -65,7 +66,8 @@ const routes = (route: Router) => {
    * @openapi
    * /v3/accounts/{account}/ft-txns/count:
    *   get:
-   *     summary: Get estimated account ft txns count
+   *     summary: Get estimated account FT transfer count
+   *     x-internal: true
    *     tags:
    *       - V3 / Accounts
    *     parameters:
@@ -96,7 +98,12 @@ const routes = (route: Router) => {
    *       200:
    *         description: Success response
    */
-  route.get('/:account/ft-txns/count', validate(request.count), service.count);
+  route.get(
+    '/:account/ft-txns/count',
+    internalOnly,
+    validate(request.count),
+    service.count,
+  );
 };
 
 export default routes;

--- a/apps/api/src/routes/v3/accounts/keys.ts
+++ b/apps/api/src/routes/v3/accounts/keys.ts
@@ -2,6 +2,7 @@ import { Router } from 'express';
 
 import request from 'nb-schemas/dist/accounts/keys/request.js';
 
+import internalOnly from '#middlewares/internalOnly';
 import { validate } from '#middlewares/validate';
 import service from '#services/v3/accounts/keys';
 
@@ -10,7 +11,7 @@ const routes = (route: Router) => {
    * @openapi
    * /v3/accounts/{account}/keys:
    *   get:
-   *     summary: Get account access keys
+   *     summary: List account access keys
    *     tags:
    *       - V3 / Accounts
    *     parameters:
@@ -48,7 +49,8 @@ const routes = (route: Router) => {
    * @openapi
    * /v3/accounts/{account}/keys/count:
    *   get:
-   *     summary: Get account access keys count
+   *     summary: Get account access key count
+   *     x-internal: true
    *     tags:
    *       - V3 / Accounts
    *     parameters:
@@ -62,7 +64,12 @@ const routes = (route: Router) => {
    *       200:
    *         description: Success response
    */
-  route.get('/:account/keys/count', validate(request.count), service.count);
+  route.get(
+    '/:account/keys/count',
+    internalOnly,
+    validate(request.count),
+    service.count,
+  );
 };
 
 export default routes;

--- a/apps/api/src/routes/v3/accounts/mts.ts
+++ b/apps/api/src/routes/v3/accounts/mts.ts
@@ -2,6 +2,7 @@ import { Router } from 'express';
 
 import request from 'nb-schemas/dist/accounts/mts/request.js';
 
+import internalOnly from '#middlewares/internalOnly';
 import { validate } from '#middlewares/validate';
 import service from '#services/v3/accounts/mts';
 
@@ -10,7 +11,7 @@ const routes = (route: Router) => {
    * @openapi
    * /v3/accounts/{account}/mt-txns:
    *   get:
-   *     summary: Get account mt txns
+   *     summary: List account multi-token transfers
    *     tags:
    *       - V3 / Accounts
    *     parameters:
@@ -70,7 +71,8 @@ const routes = (route: Router) => {
    * @openapi
    * /v3/accounts/{account}/mt-txns/count:
    *   get:
-   *     summary: Get estimated account mt txns count
+   *     summary: Get estimated account multi-token transfer count
+   *     x-internal: true
    *     tags:
    *       - V3 / Accounts
    *     parameters:
@@ -106,7 +108,12 @@ const routes = (route: Router) => {
    *       200:
    *         description: Success response
    */
-  route.get('/:account/mt-txns/count', validate(request.count), service.count);
+  route.get(
+    '/:account/mt-txns/count',
+    internalOnly,
+    validate(request.count),
+    service.count,
+  );
 };
 
 export default routes;

--- a/apps/api/src/routes/v3/accounts/nfts.ts
+++ b/apps/api/src/routes/v3/accounts/nfts.ts
@@ -2,6 +2,7 @@ import { Router } from 'express';
 
 import request from 'nb-schemas/dist/accounts/nfts/request.js';
 
+import internalOnly from '#middlewares/internalOnly';
 import { validate } from '#middlewares/validate';
 import service from '#services/v3/accounts/nfts';
 
@@ -10,7 +11,7 @@ const routes = (route: Router) => {
    * @openapi
    * /v3/accounts/{account}/nft-txns:
    *   get:
-   *     summary: Get account nft txns
+   *     summary: List account NFT transfers
    *     tags:
    *       - V3 / Accounts
    *     parameters:
@@ -70,7 +71,8 @@ const routes = (route: Router) => {
    * @openapi
    * /v3/accounts/{account}/nft-txns/count:
    *   get:
-   *     summary: Get estimated account nft txns count
+   *     summary: Get estimated account NFT transfer count
+   *     x-internal: true
    *     tags:
    *       - V3 / Accounts
    *     parameters:
@@ -106,7 +108,12 @@ const routes = (route: Router) => {
    *       200:
    *         description: Success response
    */
-  route.get('/:account/nft-txns/count', validate(request.count), service.count);
+  route.get(
+    '/:account/nft-txns/count',
+    internalOnly,
+    validate(request.count),
+    service.count,
+  );
 };
 
 export default routes;

--- a/apps/api/src/routes/v3/accounts/receipts.ts
+++ b/apps/api/src/routes/v3/accounts/receipts.ts
@@ -2,6 +2,7 @@ import { Router } from 'express';
 
 import request from 'nb-schemas/dist/accounts/receipts/request.js';
 
+import internalOnly from '#middlewares/internalOnly';
 import { validate } from '#middlewares/validate';
 import service from '#services/v3/accounts/receipts';
 
@@ -10,7 +11,7 @@ const routes = (route: Router) => {
    * @openapi
    * /v3/accounts/{account}/receipts:
    *   get:
-   *     summary: Get account receipts
+   *     summary: List account receipts
    *     tags:
    *       - V3 / Accounts
    *     parameters:
@@ -75,7 +76,8 @@ const routes = (route: Router) => {
    * @openapi
    * /v3/accounts/{account}/receipts/count:
    *   get:
-   *     summary: Get estimated account receipts count
+   *     summary: Get estimated account receipt count
+   *     x-internal: true
    *     tags:
    *       - V3 / Accounts
    *     parameters:
@@ -116,7 +118,12 @@ const routes = (route: Router) => {
    *       200:
    *         description: Success response
    */
-  route.get('/:account/receipts/count', validate(request.count), service.count);
+  route.get(
+    '/:account/receipts/count',
+    internalOnly,
+    validate(request.count),
+    service.count,
+  );
 };
 
 export default routes;

--- a/apps/api/src/routes/v3/accounts/staking.ts
+++ b/apps/api/src/routes/v3/accounts/staking.ts
@@ -2,6 +2,7 @@ import { Router } from 'express';
 
 import request from 'nb-schemas/dist/accounts/staking/request.js';
 
+import internalOnly from '#middlewares/internalOnly';
 import { validate } from '#middlewares/validate';
 import service from '#services/v3/accounts/staking';
 
@@ -10,7 +11,7 @@ const routes = (route: Router) => {
    * @openapi
    * /v3/accounts/{account}/staking-txns:
    *   get:
-   *     summary: Get account staking txns
+   *     summary: List account staking transactions
    *     tags:
    *       - V3 / Accounts
    *     parameters:
@@ -60,7 +61,8 @@ const routes = (route: Router) => {
    * @openapi
    * /v3/accounts/{account}/staking-txns/count:
    *   get:
-   *     summary: Get estimated account staking txns count
+   *     summary: Get estimated account staking transaction count
+   *     x-internal: true
    *     tags:
    *       - V3 / Accounts
    *     parameters:
@@ -88,6 +90,7 @@ const routes = (route: Router) => {
    */
   route.get(
     '/:account/staking-txns/count',
+    internalOnly,
     validate(request.count),
     service.count,
   );

--- a/apps/api/src/routes/v3/accounts/stats.ts
+++ b/apps/api/src/routes/v3/accounts/stats.ts
@@ -10,7 +10,7 @@ const routes = (route: Router) => {
    * @openapi
    * /v3/accounts/{account}/stats:
    *   get:
-   *     summary: Get account stats overview
+   *     summary: Get account statistics overview
    *     tags:
    *       - V3 / Accounts
    *     parameters:
@@ -29,7 +29,7 @@ const routes = (route: Router) => {
    * @openapi
    * /v3/accounts/{account}/stats/heatmap:
    *   get:
-   *     summary: Get account txns heatmap
+   *     summary: Get account transaction heatmap
    *     tags:
    *       - V3 / Accounts
    *     parameters:
@@ -53,7 +53,7 @@ const routes = (route: Router) => {
    * @openapi
    * /v3/accounts/{account}/stats/txns:
    *   get:
-   *     summary: Get account txn stats
+   *     summary: Get account transaction statistics
    *     tags:
    *       - V3 / Accounts
    *     parameters:
@@ -80,7 +80,7 @@ const routes = (route: Router) => {
    * @openapi
    * /v3/accounts/{account}/stats/balance:
    *   get:
-   *     summary: Get account balance stats
+   *     summary: Get account balance history
    *     tags:
    *       - V3 / Accounts
    *     parameters:
@@ -111,7 +111,7 @@ const routes = (route: Router) => {
    * @openapi
    * /v3/accounts/{account}/stats/near:
    *   get:
-   *     summary: Get account near stats
+   *     summary: Get account NEAR statistics
    *     tags:
    *       - V3 / Accounts
    *     parameters:
@@ -138,7 +138,7 @@ const routes = (route: Router) => {
    * @openapi
    * /v3/accounts/{account}/stats/fts:
    *   get:
-   *     summary: Get account ft stats
+   *     summary: Get account FT statistics
    *     tags:
    *       - V3 / Accounts
    *     parameters:

--- a/apps/api/src/routes/v3/accounts/txns.ts
+++ b/apps/api/src/routes/v3/accounts/txns.ts
@@ -2,6 +2,7 @@ import { Router } from 'express';
 
 import request from 'nb-schemas/dist/accounts/txns/request.js';
 
+import internalOnly from '#middlewares/internalOnly';
 import { validate } from '#middlewares/validate';
 import service from '#services/v3/accounts/txns';
 
@@ -10,7 +11,7 @@ const routes = (route: Router) => {
    * @openapi
    * /v3/accounts/{account}/txns:
    *   get:
-   *     summary: Get account txns
+   *     summary: List account transactions
    *     tags:
    *       - V3 / Accounts
    *     parameters:
@@ -65,7 +66,8 @@ const routes = (route: Router) => {
    * @openapi
    * /v3/accounts/{account}/txns/count:
    *   get:
-   *     summary: Get estimated account txns count
+   *     summary: Get estimated account transaction count
+   *     x-internal: true
    *     tags:
    *       - V3 / Accounts
    *     parameters:
@@ -96,7 +98,12 @@ const routes = (route: Router) => {
    *       200:
    *         description: Success response
    */
-  route.get('/:account/txns/count', validate(request.count), service.count);
+  route.get(
+    '/:account/txns/count',
+    internalOnly,
+    validate(request.count),
+    service.count,
+  );
 };
 
 export default routes;

--- a/apps/api/src/routes/v3/blocks.ts
+++ b/apps/api/src/routes/v3/blocks.ts
@@ -2,6 +2,7 @@ import { Router } from 'express';
 
 import request from 'nb-schemas/dist/blocks/request.js';
 
+import internalOnly from '#middlewares/internalOnly';
 import { bearerAuth } from '#middlewares/passport';
 import rateLimiter from '#middlewares/rateLimiter';
 import { validate } from '#middlewares/validate';
@@ -16,7 +17,7 @@ const routes = (app: Router) => {
    * @openapi
    * /v3/blocks:
    *   get:
-   *     summary: Get all blocks
+   *     summary: List blocks
    *     tags:
    *       - V3 / Blocks
    *     parameters:
@@ -48,20 +49,21 @@ const routes = (app: Router) => {
    * @openapi
    * /v3/blocks/count:
    *   get:
-   *     summary: Get estimated blocks count
+   *     summary: Get estimated block count
+   *     x-internal: true
    *     tags:
    *       - V3 / Blocks
    *     responses:
    *       200:
    *         description: Success response
    */
-  route.get('/count', service.count);
+  route.get('/count', internalOnly, service.count);
 
   /**
    * @openapi
    * /v3/blocks/latest:
    *   get:
-   *     summary: Get the latest blocks
+   *     summary: List latest blocks
    *     description: ⚠️ Response is cached for 5 seconds
    *     tags:
    *       - V3 / Blocks
@@ -84,7 +86,7 @@ const routes = (app: Router) => {
    * @openapi
    * /v3/blocks/stats:
    *   get:
-   *     summary: Get 24h block stats
+   *     summary: Get 24-hour block statistics
    *     tags:
    *       - V3 / Blocks
    *     responses:
@@ -97,7 +99,7 @@ const routes = (app: Router) => {
    * @openapi
    * /v3/blocks/{hash}:
    *   get:
-   *     summary: Get a block
+   *     summary: Get block by hash
    *     tags:
    *       - V3 / Blocks
    *     parameters:

--- a/apps/api/src/routes/v3/fts/contract.ts
+++ b/apps/api/src/routes/v3/fts/contract.ts
@@ -16,7 +16,7 @@ const routes = (app: Router) => {
    * @openapi
    * /v3/fts/{contract}:
    *   get:
-   *     summary: Get token info
+   *     summary: Get FT contract details
    *     tags:
    *       - V3 / FTs
    *     parameters:
@@ -36,7 +36,7 @@ const routes = (app: Router) => {
    * @openapi
    * /v3/fts/{contract}/txns:
    *   get:
-   *     summary: Get token transfers
+   *     summary: List FT contract transfers
    *     tags:
    *       - V3 / FTs
    *     parameters:
@@ -86,7 +86,7 @@ const routes = (app: Router) => {
    * @openapi
    * /v3/fts/{contract}/txns/count:
    *   get:
-   *     summary: Get token transfers count
+   *     summary: Get FT contract transfer count
    *     tags:
    *       - V3 / FTs
    *     parameters:
@@ -122,7 +122,7 @@ const routes = (app: Router) => {
    * @openapi
    * /v3/fts/{contract}/holders:
    *   get:
-   *     summary: Get token holders
+   *     summary: List FT contract holders
    *     tags:
    *       - V3 / FTs
    *     parameters:
@@ -164,7 +164,7 @@ const routes = (app: Router) => {
    * @openapi
    * /v3/fts/{contract}/holders/count:
    *   get:
-   *     summary: Get token holders count
+   *     summary: Get FT contract holder count
    *     tags:
    *       - V3 / FTs
    *     parameters:

--- a/apps/api/src/routes/v3/fts/index.ts
+++ b/apps/api/src/routes/v3/fts/index.ts
@@ -2,6 +2,7 @@ import { Router } from 'express';
 
 import request from 'nb-schemas/dist/fts/request.js';
 
+import internalOnly from '#middlewares/internalOnly';
 import { bearerAuth } from '#middlewares/passport';
 import rateLimiter from '#middlewares/rateLimiter';
 import { validate } from '#middlewares/validate';
@@ -19,7 +20,7 @@ const routes = (app: Router) => {
    * @openapi
    * /v3/fts:
    *   get:
-   *     summary: Get top tokens
+   *     summary: List top fungible tokens
    *     tags:
    *       - V3 / FTs
    *     parameters:
@@ -70,7 +71,8 @@ const routes = (app: Router) => {
    * @openapi
    * /v3/fts/count:
    *   get:
-   *     summary: Get top tokens count
+   *     summary: Get fungible token count
+   *     x-internal: true
    *     tags:
    *       - V3 / FTs
    *     parameters:
@@ -83,13 +85,13 @@ const routes = (app: Router) => {
    *       200:
    *         description: Success response
    */
-  route.get('/count', validate(request.count), service.count);
+  route.get('/count', internalOnly, validate(request.count), service.count);
 
   /**
    * @openapi
    * /v3/fts/txns:
    *   get:
-   *     summary: Get all token transfers
+   *     summary: List all FT transfers
    *     tags:
    *       - V3 / FTs
    *     parameters:
@@ -128,7 +130,8 @@ const routes = (app: Router) => {
    * @openapi
    * /v3/fts/txns/count:
    *   get:
-   *     summary: Get token transfers count
+   *     summary: Get FT transfer count
+   *     x-internal: true
    *     tags:
    *       - V3 / FTs
    *     parameters:
@@ -143,7 +146,12 @@ const routes = (app: Router) => {
    *       200:
    *         description: Success response
    */
-  route.get('/txns/count', validate(request.txnCount), service.txnCount);
+  route.get(
+    '/txns/count',
+    internalOnly,
+    validate(request.txnCount),
+    service.txnCount,
+  );
 
   return app;
 };

--- a/apps/api/src/routes/v3/keys.ts
+++ b/apps/api/src/routes/v3/keys.ts
@@ -16,7 +16,7 @@ const routes = (app: Router) => {
    * @openapi
    * /v3/keys/{key}:
    *   get:
-   *     summary: Get access keys
+   *     summary: Get access key info
    *     tags:
    *       - V3 / Keys
    *     parameters:

--- a/apps/api/src/routes/v3/multichain/signatures.ts
+++ b/apps/api/src/routes/v3/multichain/signatures.ts
@@ -2,6 +2,7 @@ import { Router } from 'express';
 
 import request from 'nb-schemas/dist/multichain/request.js';
 
+import internalOnly from '#middlewares/internalOnly';
 import { bearerAuth } from '#middlewares/passport';
 import rateLimiter from '#middlewares/rateLimiter';
 import { validate } from '#middlewares/validate';
@@ -16,7 +17,7 @@ const routes = (app: Router) => {
    * @openapi
    * /v3/multichain/signatures:
    *   get:
-   *     summary: Get all multichain signature txns
+   *     summary: List multichain signature transactions
    *     tags:
    *       - V3 / Multichain
    *     parameters:
@@ -76,7 +77,8 @@ const routes = (app: Router) => {
    * @openapi
    * /v3/multichain/signatures/count:
    *   get:
-   *     summary: Get estimated multichain signature txns count
+   *     summary: Get estimated multichain signature count
+   *     x-internal: true
    *     tags:
    *       - V3 / Multichain
    *     parameters:
@@ -112,13 +114,18 @@ const routes = (app: Router) => {
    *       200:
    *         description: Success response
    */
-  route.get('/signatures/count', validate(request.count), service.count);
+  route.get(
+    '/signatures/count',
+    internalOnly,
+    validate(request.count),
+    service.count,
+  );
 
   /**
    * @openapi
    * /v3/multichain/signatures/stats:
    *   get:
-   *     summary: Get 24h multichain signature stats
+   *     summary: Get 24-hour multichain signature statistics
    *     tags:
    *       - V3 / Multichain
    *     responses:

--- a/apps/api/src/routes/v3/nfts/contract.ts
+++ b/apps/api/src/routes/v3/nfts/contract.ts
@@ -16,7 +16,7 @@ const routes = (app: Router) => {
    * @openapi
    * /v3/nfts/{contract}:
    *   get:
-   *     summary: Get nft info
+   *     summary: Get NFT contract details
    *     tags:
    *       - V3 / NFTs
    *     parameters:
@@ -36,7 +36,7 @@ const routes = (app: Router) => {
    * @openapi
    * /v3/nfts/{contract}/txns:
    *   get:
-   *     summary: Get nft transfers
+   *     summary: List NFT contract transfers
    *     tags:
    *       - V3 / NFTs
    *     parameters:
@@ -86,7 +86,7 @@ const routes = (app: Router) => {
    * @openapi
    * /v3/nfts/{contract}/txns/count:
    *   get:
-   *     summary: Get nft transfers count
+   *     summary: Get NFT contract transfer count
    *     tags:
    *       - V3 / NFTs
    *     parameters:
@@ -122,7 +122,7 @@ const routes = (app: Router) => {
    * @openapi
    * /v3/nfts/{contract}/holders:
    *   get:
-   *     summary: Get nft holders
+   *     summary: List NFT contract holders
    *     tags:
    *       - V3 / NFTs
    *     parameters:
@@ -164,7 +164,7 @@ const routes = (app: Router) => {
    * @openapi
    * /v3/nfts/{contract}/holders/count:
    *   get:
-   *     summary: Get nft holders count
+   *     summary: Get NFT contract holder count
    *     tags:
    *       - V3 / NFTs
    *     parameters:

--- a/apps/api/src/routes/v3/nfts/index.ts
+++ b/apps/api/src/routes/v3/nfts/index.ts
@@ -2,6 +2,7 @@ import { Router } from 'express';
 
 import request from 'nb-schemas/dist/nfts/request.js';
 
+import internalOnly from '#middlewares/internalOnly';
 import { bearerAuth } from '#middlewares/passport';
 import rateLimiter from '#middlewares/rateLimiter';
 import { validate } from '#middlewares/validate';
@@ -21,7 +22,7 @@ const routes = (app: Router) => {
    * @openapi
    * /v3/nfts:
    *   get:
-   *     summary: Get top nfts
+   *     summary: List top NFT collections
    *     tags:
    *       - V3 / NFTs
    *     parameters:
@@ -72,7 +73,8 @@ const routes = (app: Router) => {
    * @openapi
    * /v3/nfts/count:
    *   get:
-   *     summary: Get top nfts count
+   *     summary: Get NFT collection count
+   *     x-internal: true
    *     tags:
    *       - V3 / NFTs
    *     parameters:
@@ -85,13 +87,13 @@ const routes = (app: Router) => {
    *       200:
    *         description: Success response
    */
-  route.get('/count', validate(request.count), service.count);
+  route.get('/count', internalOnly, validate(request.count), service.count);
 
   /**
    * @openapi
    * /v3/nfts/txns:
    *   get:
-   *     summary: Get all nft transfers
+   *     summary: List all NFT transfers
    *     tags:
    *       - V3 / NFTs
    *     parameters:
@@ -130,7 +132,8 @@ const routes = (app: Router) => {
    * @openapi
    * /v3/nfts/txns/count:
    *   get:
-   *     summary: Get nft transfers count
+   *     summary: Get NFT transfer count
+   *     x-internal: true
    *     tags:
    *       - V3 / NFTs
    *     parameters:
@@ -145,7 +148,12 @@ const routes = (app: Router) => {
    *       200:
    *         description: Success response
    */
-  route.get('/txns/count', validate(request.txnCount), service.txnCount);
+  route.get(
+    '/txns/count',
+    internalOnly,
+    validate(request.txnCount),
+    service.txnCount,
+  );
 
   return app;
 };

--- a/apps/api/src/routes/v3/nfts/token.ts
+++ b/apps/api/src/routes/v3/nfts/token.ts
@@ -16,7 +16,7 @@ const routes = (app: Router) => {
    * @openapi
    * /v3/nfts/{contract}/tokens:
    *   get:
-   *     summary: Get nft tokens
+   *     summary: List NFT tokens in a contract
    *     tags:
    *       - V3 / NFTs
    *     parameters:
@@ -54,7 +54,7 @@ const routes = (app: Router) => {
    * @openapi
    * /v3/nfts/{contract}/tokens/count:
    *   get:
-   *     summary: Get nft tokens count
+   *     summary: Get NFT token count in a contract
    *     tags:
    *       - V3 / NFTs
    *     parameters:
@@ -78,7 +78,7 @@ const routes = (app: Router) => {
    * @openapi
    * /v3/nfts/{contract}/tokens/{token}:
    *   get:
-   *     summary: Get nft token info
+   *     summary: Get NFT token details
    *     tags:
    *       - V3 / NFTs
    *     parameters:
@@ -104,7 +104,7 @@ const routes = (app: Router) => {
    * @openapi
    * /v3/nfts/{contract}/tokens/{token}/txns:
    *   get:
-   *     summary: Get nft token transfers
+   *     summary: List NFT token transfers
    *     tags:
    *       - V3 / NFTs
    *     parameters:
@@ -159,7 +159,7 @@ const routes = (app: Router) => {
    * @openapi
    * /v3/nfts/{contract}/tokens/{token}/txns/count:
    *   get:
-   *     summary: Get nft token transfers count
+   *     summary: Get NFT token transfer count
    *     tags:
    *       - V3 / NFTs
    *     parameters:

--- a/apps/api/src/routes/v3/search.ts
+++ b/apps/api/src/routes/v3/search.ts
@@ -16,7 +16,7 @@ const routes = (app: Router) => {
    * @openapi
    * /v3/search:
    *   get:
-   *     summary: Search
+   *     summary: Search all entities
    *     tags:
    *       - V3 / Search
    *     parameters:
@@ -73,7 +73,7 @@ const routes = (app: Router) => {
    * @openapi
    * /v3/search/keys:
    *   get:
-   *     summary: Search keys
+   *     summary: Search access keys
    *     tags:
    *       - V3 / Search
    *     parameters:
@@ -92,7 +92,7 @@ const routes = (app: Router) => {
    * @openapi
    * /v3/search/fts:
    *   get:
-   *     summary: Search fts
+   *     summary: Search fungible tokens
    *     tags:
    *       - V3 / Search
    *     parameters:
@@ -111,7 +111,7 @@ const routes = (app: Router) => {
    * @openapi
    * /v3/search/nfts:
    *   get:
-   *     summary: Search nfts
+   *     summary: Search NFTs
    *     tags:
    *       - V3 / Search
    *     parameters:
@@ -149,7 +149,7 @@ const routes = (app: Router) => {
    * @openapi
    * /v3/search/txns:
    *   get:
-   *     summary: Search txns
+   *     summary: Search transactions
    *     tags:
    *       - V3 / Search
    *     parameters:

--- a/apps/api/src/routes/v3/stats.ts
+++ b/apps/api/src/routes/v3/stats.ts
@@ -12,7 +12,7 @@ const routes = (app: Router) => {
    * @openapi
    * /v3/stats:
    *   get:
-   *     summary: Stats
+   *     summary: Get network statistics
    *     tags:
    *       - V3 / Stats
    *     responses:
@@ -25,7 +25,7 @@ const routes = (app: Router) => {
    * @openapi
    * /v3/daily-stats:
    *   get:
-   *     summary: Daily stats
+   *     summary: Get daily network statistics
    *     tags:
    *       - V3 / Stats
    *     parameters:
@@ -55,7 +55,7 @@ const routes = (app: Router) => {
    * @openapi
    * /v3/tps-stats:
    *   get:
-   *     summary: Tps stats
+   *     summary: Get transactions-per-second statistics
    *     tags:
    *       - V3 / Stats
    *     responses:

--- a/apps/api/src/routes/v3/txns.ts
+++ b/apps/api/src/routes/v3/txns.ts
@@ -2,6 +2,7 @@ import { Router } from 'express';
 
 import request from 'nb-schemas/dist/txns/request.js';
 
+import internalOnly from '#middlewares/internalOnly';
 import { bearerAuth } from '#middlewares/passport';
 import rateLimiter from '#middlewares/rateLimiter';
 import { validate } from '#middlewares/validate';
@@ -16,7 +17,7 @@ const routes = (app: Router) => {
    * @openapi
    * /v3/txns:
    *   get:
-   *     summary: Get all txns
+   *     summary: List transactions
    *     tags:
    *       - V3 / Txns
    *     parameters:
@@ -60,7 +61,8 @@ const routes = (app: Router) => {
    * @openapi
    * /v3/txns/count:
    *   get:
-   *     summary: Get estimated txns count
+   *     summary: Get estimated transaction count
+   *     x-internal: true
    *     tags:
    *       - V3 / Txns
    *     parameters:
@@ -88,13 +90,13 @@ const routes = (app: Router) => {
    *       200:
    *         description: Success response
    */
-  route.get('/count', validate(request.count), service.count);
+  route.get('/count', internalOnly, validate(request.count), service.count);
 
   /**
    * @openapi
    * /v3/txns/latest:
    *   get:
-   *     summary: Get the latest txns
+   *     summary: List latest transactions
    *     description: ⚠️ Response is cached for 5 seconds
    *     tags:
    *       - V3 / Txns
@@ -117,7 +119,7 @@ const routes = (app: Router) => {
    * @openapi
    * /v3/txns/stats:
    *   get:
-   *     summary: Get 24h transaction stats
+   *     summary: Get 24-hour transaction statistics
    *     tags:
    *       - V3 / Txns
    *     responses:
@@ -130,7 +132,7 @@ const routes = (app: Router) => {
    * @openapi
    * /v3/txns/{hash}:
    *   get:
-   *     summary: Get a txn
+   *     summary: Get transaction by hash
    *     tags:
    *       - V3 / Txns
    *     parameters:
@@ -150,7 +152,7 @@ const routes = (app: Router) => {
    * @openapi
    * /v3/txns/{hash}/receipts:
    *   get:
-   *     summary: Get txn receipts
+   *     summary: List transaction receipts
    *     tags:
    *       - V3 / Txns
    *     parameters:
@@ -170,7 +172,7 @@ const routes = (app: Router) => {
    * @openapi
    * /v3/txns/{hash}/fts:
    *   get:
-   *     summary: Get txn ft events
+   *     summary: List transaction FT events
    *     tags:
    *       - V3 / Txns
    *     parameters:
@@ -190,7 +192,7 @@ const routes = (app: Router) => {
    * @openapi
    * /v3/txns/{hash}/nfts:
    *   get:
-   *     summary: Get txn nft events
+   *     summary: List transaction NFT events
    *     tags:
    *       - V3 / Txns
    *     parameters:
@@ -210,7 +212,7 @@ const routes = (app: Router) => {
    * @openapi
    * /v3/txns/{hash}/mts:
    *   get:
-   *     summary: Get txn mt events
+   *     summary: List transaction multi-token events
    *     tags:
    *       - V3 / Txns
    *     parameters:

--- a/apps/api/src/routes/validators.ts
+++ b/apps/api/src/routes/validators.ts
@@ -17,7 +17,7 @@ const routes = (app: Router) => {
    *   get:
    *     summary: Get validators
    *     tags:
-   *       - Validators
+   *       - Legacy / Validators
    *     parameters:
    *       - in: query
    *         name: page

--- a/yarn.lock
+++ b/yarn.lock
@@ -11302,25 +11302,34 @@
   resolved "https://registry.yarnpkg.com/@safe-global/safe-gateway-typescript-sdk/-/safe-gateway-typescript-sdk-3.22.4.tgz#9109a538df40f778666a3e6776e7a08c757e893d"
   integrity sha512-Z7Z8w3GEJdJ/paF+NK23VN4AwqWPadq0AeRYjYLjIBiPWpRB2UO/FKq7ONABEq0YFgNPklazIV4IExQU1gavXA==
 
-"@scalar/express-api-reference@0.4.173":
-  version "0.4.173"
-  resolved "https://registry.yarnpkg.com/@scalar/express-api-reference/-/express-api-reference-0.4.173.tgz#801bbc066a9b79478a28f59acc80e93a1da7295c"
-  integrity sha512-C/s+rdImUb7gLbYRH6ICZjVPV8SHHMwJQ/Fiu6fVGomPldi0fpTDMaXH+9jRIlTm3LR6ACl/OlH7MXcPPRaFSA==
+"@scalar/client-side-rendering@0.1.3":
+  version "0.1.3"
+  resolved "https://registry.yarnpkg.com/@scalar/client-side-rendering/-/client-side-rendering-0.1.3.tgz#58689181f181576f62c9d92b403cc3463a6a9b40"
+  integrity sha512-rUI5EQA8y0xivzqc/AwExZYW8HRfQSFxPxvvuLjHTCATpKz0xcQBGVJQIPOmp78NJyO8mnQmltE1AxIdtvdPGg==
   dependencies:
-    "@scalar/types" "0.0.25"
+    "@scalar/types" "0.9.2"
 
-"@scalar/openapi-types@0.1.5":
-  version "0.1.5"
-  resolved "https://registry.yarnpkg.com/@scalar/openapi-types/-/openapi-types-0.1.5.tgz#77e01b88c691a08ed8cbc5a1e4f22c84f4d6c2f8"
-  integrity sha512-6geH9ehvQ/sG/xUyy3e0lyOw3BaY5s6nn22wHjEJhcobdmWyFER0O6m7AU0ZN4QTjle/gYvFJOjj552l/rsNSw==
-
-"@scalar/types@0.0.25":
-  version "0.0.25"
-  resolved "https://registry.yarnpkg.com/@scalar/types/-/types-0.0.25.tgz#20187e3bb293af6e2803eea26654487d97dbc13d"
-  integrity sha512-sGnOFnfiSn4o23rklU/jrg81hO+630bsFIdHg8MZ/w2Nc6IoUwARA2hbe4d4Fg+D0KBu40Tan/L+WAYDXkTJQg==
+"@scalar/express-api-reference@0.9.10":
+  version "0.9.10"
+  resolved "https://registry.yarnpkg.com/@scalar/express-api-reference/-/express-api-reference-0.9.10.tgz#09182fbad475481bc436f0623f268aa0806e3124"
+  integrity sha512-udv4u0nz6NDXG3qyGOzp/uVKZn0ksLdVr5D3R5nx+XhO1ZYdNNZoZYjX80Q5NXL68XJAVNMVl+4SObjuwbBTag==
   dependencies:
-    "@scalar/openapi-types" "0.1.5"
-    "@unhead/schema" "^1.11.11"
+    "@scalar/client-side-rendering" "0.1.3"
+
+"@scalar/helpers@0.5.2":
+  version "0.5.2"
+  resolved "https://registry.yarnpkg.com/@scalar/helpers/-/helpers-0.5.2.tgz#7771c5f03dd4b014071d9d321069113fed438720"
+  integrity sha512-Pi1GAl8jO6ungmGj2sjDfCfqiBNrKW6HXDZmminV94ybGU/KtRLOqHwd0n9FIhY3j0RYGpGC0VCuniCICfQPHg==
+
+"@scalar/types@0.9.2":
+  version "0.9.2"
+  resolved "https://registry.yarnpkg.com/@scalar/types/-/types-0.9.2.tgz#077affae59afbfe3823279f30e540e37c5bac1c8"
+  integrity sha512-aLn7QTHafpjrN/whup7U5/CHaoPPaYMNtz4L/2yfN5GDSy3AbDM7kV1q8s3nMQIhvC1uscxfriV+KhEND+xHvA==
+  dependencies:
+    "@scalar/helpers" "0.5.2"
+    nanoid "^5.1.6"
+    type-fest "^5.3.1"
+    zod "^4.3.5"
 
 "@scure/base@1.1.3":
   version "1.1.3"
@@ -14902,14 +14911,6 @@
   dependencies:
     "@typescript-eslint/types" "6.9.0"
     eslint-visitor-keys "^3.4.1"
-
-"@unhead/schema@^1.11.11":
-  version "1.11.15"
-  resolved "https://registry.yarnpkg.com/@unhead/schema/-/schema-1.11.15.tgz#600f659d44f415b3aa47636df9341464eb53185a"
-  integrity sha512-UkLz1dqw4yoh4jELEyLsgSG7yrXc+gv68GkQeTv8LysEPa8sXtFqhfuqTBLhY3sHqSnP8RkDknhtFhG2S3fuKQ==
-  dependencies:
-    hookable "^5.5.3"
-    zhead "^2.2.4"
 
 "@vercel/build-utils@8.4.12":
   version "8.4.12"
@@ -22184,11 +22185,6 @@ hoist-non-react-statics@^3.0.0, hoist-non-react-statics@^3.3.0, hoist-non-react-
   dependencies:
     react-is "^16.7.0"
 
-hookable@^5.5.3:
-  version "5.5.3"
-  resolved "https://registry.yarnpkg.com/hookable/-/hookable-5.5.3.tgz#6cfc358984a1ef991e2518cb9ed4a778bbd3215d"
-  integrity sha512-Yc+BQe8SvoXH1643Qez1zqLRmbA5rCL+sSmk6TVos0LWVfNIB7PGncdlId77WzLGSIB5KaWgTaNTs2lNVEI6VQ==
-
 html-escaper@^2.0.0:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/html-escaper/-/html-escaper-2.0.2.tgz#dfd60027da36a36dfcbe236262c00a5822681453"
@@ -25364,6 +25360,11 @@ nanoid@^4.0.1:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-4.0.2.tgz#140b3c5003959adbebf521c170f282c5e7f9fb9e"
   integrity sha512-7ZtY5KTCNheRGfEFxnedV5zFiORN1+Y1N6zvPTnHQd8ENUvfaDBeuJDZb2bN/oXwXxu3qkTXDzy57W5vAmDTBw==
+
+nanoid@^5.1.6:
+  version "5.1.9"
+  resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-5.1.9.tgz#aac959acf7d685269fb1be7f70a90d9db0848948"
+  integrity sha512-ZUvP7KeBLe3OZ1ypw6dI/TzYJuvHP77IM4Ry73waSQTLn8/g8rpdjfyVAh7t1/+FjBtG4lCP42MEbDxOsRpBMw==
 
 nanomatch@^1.2.9:
   version "1.2.13"
@@ -29837,16 +29838,7 @@ string-length@^4.0.1:
     char-regex "^1.0.2"
     strip-ansi "^6.0.0"
 
-"string-width-cjs@npm:string-width@^4.2.0":
-  version "4.2.3"
-  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
-  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
-  dependencies:
-    emoji-regex "^8.0.0"
-    is-fullwidth-code-point "^3.0.0"
-    strip-ansi "^6.0.1"
-
-"string-width@^1.0.2 || 2 || 3 || 4", string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
+"string-width-cjs@npm:string-width@^4.2.0", "string-width@^1.0.2 || 2 || 3 || 4", string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -29925,14 +29917,7 @@ string_decoder@~1.1.1:
   dependencies:
     safe-buffer "~5.1.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
-  version "6.0.1"
-  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
-  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
-  dependencies:
-    ansi-regex "^5.0.1"
-
-strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -30139,6 +30124,11 @@ tabbable@^6.4.0:
   version "6.4.0"
   resolved "https://registry.yarnpkg.com/tabbable/-/tabbable-6.4.0.tgz#36eb7a06d80b3924a22095daf45740dea3bf5581"
   integrity sha512-05PUHKSNE8ou2dwIxTngl4EzcnsCDZGJ/iCLtDflR/SHB/ny14rXc+qU5P4mG9JkusiV7EivzY9Mhm55AzAvCg==
+
+tagged-tag@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/tagged-tag/-/tagged-tag-1.0.0.tgz#a0b5917c2864cba54841495abfa3f6b13edcf4d6"
+  integrity sha512-yEFYrVhod+hdNyx7g5Bnkkb0G6si8HJurOoOEgC8B/O0uXLHlaey/65KRv6cuWBNhBgHKAROVpc7QyYqE5gFng==
 
 tailwind-merge@~3.4.0:
   version "3.4.0"
@@ -30702,6 +30692,13 @@ type-fest@^2.19.0:
   version "2.19.0"
   resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-2.19.0.tgz#88068015bb33036a598b952e55e9311a60fd3a9b"
   integrity sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==
+
+type-fest@^5.3.1:
+  version "5.6.0"
+  resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-5.6.0.tgz#502f7a003b7309e96a7e17052cc2ab2c7e5c7a31"
+  integrity sha512-8ZiHFm91orbSAe2PSAiSVBVko18pbhbiB3U9GglSzF/zCGkR+rxpHx6sEMCUm4kxY4LjDIUGgCfUMtwfZfjfUA==
+  dependencies:
+    tagged-tag "^1.0.0"
 
 type-is@~1.6.18:
   version "1.6.18"
@@ -31697,7 +31694,7 @@ wrangler@^3.86.0:
   optionalDependencies:
     fsevents "~2.3.2"
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
@@ -31710,15 +31707,6 @@ wrap-ansi@^6.2.0:
   version "6.2.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-6.2.0.tgz#e9393ba07102e6c91a3b221478f0257cd2856e53"
   integrity sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==
-  dependencies:
-    ansi-styles "^4.0.0"
-    string-width "^4.1.0"
-    strip-ansi "^6.0.0"
-
-wrap-ansi@^7.0.0:
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
-  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
   dependencies:
     ansi-styles "^4.0.0"
     string-width "^4.1.0"
@@ -31987,11 +31975,6 @@ z-schema@^5.0.1:
   optionalDependencies:
     commander "^10.0.0"
 
-zhead@^2.2.4:
-  version "2.2.4"
-  resolved "https://registry.yarnpkg.com/zhead/-/zhead-2.2.4.tgz#87cd1e2c3d2f465fa9f43b8db23f9716dfe6bed7"
-  integrity sha512-8F0OI5dpWIA5IGG5NHUg9staDwz/ZPxZtvGVf01j7vHqSyZ0raHY+78atOVxRqb73AotX22uV1pXt3gYSstGag==
-
 zod@3.22.4:
   version "3.22.4"
   resolved "https://registry.yarnpkg.com/zod/-/zod-3.22.4.tgz#f31c3a9386f61b1f228af56faa9255e845cf3fff"
@@ -32007,7 +31990,7 @@ zod@^4.0.5:
   resolved "https://registry.yarnpkg.com/zod/-/zod-4.1.5.tgz#7a21fc3178928ede50a28f7d0db4414c4cdb0161"
   integrity sha512-rcUUZqlLJgBC33IT3PNMgsCq6TzLQEG/Ei/KTCU0PedSWRMAXoOUN+4t/0H+Q8bdnLPdqUYnvboJT0bn/229qg==
 
-zod@~4.3.6:
+zod@^4.3.5, zod@~4.3.6:
   version "4.3.6"
   resolved "https://registry.yarnpkg.com/zod/-/zod-4.3.6.tgz#89c56e0aa7d2b05107d894412227087885ab112a"
   integrity sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==


### PR DESCRIPTION
- Upgrade @scalar/express-api-reference 0.4.173 → 0.9.10
- Restructure docs: V3 tags primary, V1/V2 renamed to Legacy/*
- Rewrite V3 endpoint summaries for clarity and consistency
- Add internalOnly middleware to gate V3 count endpoints
- Mark count endpoints x-internal in OpenAPI spec
