### PR TITLE
feat(api): split API docs into main and legacy pages

### DIFF
--- a/apps/api/src/libs/apiDocumentation.ts
+++ b/apps/api/src/libs/apiDocumentation.ts
@@ -8,9 +8,42 @@ import { Network } from 'nb-types';
 
 import config from '#config';
 
+const scalarCss = `
+  .light-mode .introduction-section {
+    background: url(https://nearblocks.io/images/nearblocksblack.svg) no-repeat;
+    background-size: auto;
+    padding-top: 60px;
+    margin-top: 12px;
+  }
+  .dark-mode .introduction-section {
+    background: url(https://nearblocks.io/images/nearblocksblack_dark.svg) no-repeat;
+    background-size: auto;
+    padding-top: 60px;
+    margin-top: 12px;
+  }
+`;
+
+const scalarMeta = {
+  description:
+    'NearBlocks REST API documentation for the NEAR Protocol. Provides endpoints to access blockchain data and integrate seamlessly with NEAR.',
+  ogDescription:
+    'NearBlocks REST API documentation for the NEAR Protocol. Provides endpoints to access blockchain data and integrate seamlessly with NEAR.',
+  ogTitle: 'Near(Ⓝ) REST API | NearBlocks',
+  title: 'Near(Ⓝ) REST API | NearBlocks',
+  twitterDescription:
+    'NearBlocks REST API documentation for the NEAR Protocol. Provides endpoints to access blockchain data and integrate seamlessly with NEAR.',
+  twitterTitle: 'Near(Ⓝ) REST API | NearBlocks',
+};
+
+const servers = [
+  { description: 'Mainnet', url: config.mainnetUrl },
+  { description: 'Testnet', url: config.testnetUrl },
+];
+
 const apiDocumentation = async (app: Application, dir: string) => {
-  const options = {
-    apis: [path.join(dir, '**/*.{ts,js}')],
+  // ── Main API docs (v3 only) ───────────────────────────────────────
+  const mainOptions = {
+    apis: [path.join(dir, 'routes/v3/**/*.{ts,js}')],
     definition: {
       components: {
         securitySchemes: {
@@ -41,216 +74,149 @@ const apiDocumentation = async (app: Application, dir: string) => {
           <li><a href="https://nearblocks.io/contact">NearBlocks Support</a></li>
         </ul>
         <h2>Authentication</h2>
-        <p>Include your API key in requests using as <code>Authorization</code> header with the following format:</p>
+        <p>Include your API key in requests using the <code>Authorization</code> header with the following format:</p>
         <p>Replace API_KEY with the key string of your API key.</p>
         <p>For example, to pass an API key for an Account API:</p>
         <pre><code> curl -X GET -H "Authorization: Bearer API_KEY" "${
           config.network === Network.MAINNET
             ? config.mainnetUrl
             : config.testnetUrl
-        }/v1/account/wrap.near"</pre></code></p>
+        }/v3/accounts/wrap.near"</pre></code></p>
+        <h2>Legacy API</h2>
+        <p>Documentation for deprecated v1/v2 endpoints is available at <a href="/api-docs/legacy">/api-docs/legacy</a>. These endpoints will be removed in a future release.</p>
         `,
         title: ' ',
         version: '1.0.0',
       },
       openapi: '3.0.0',
-      servers: [
-        { description: 'Mainnet', url: config.mainnetUrl },
-        { description: 'Testnet', url: config.testnetUrl },
-      ],
+      servers,
       tags: [
-        // ── V3 (current) ──────────────────────────────────────────────
         {
           description:
             'Retrieve account details, balances, contract metadata, access keys, token holdings, and transaction history for any NEAR account.',
-          name: 'V3 / Accounts',
+          name: 'Accounts',
         },
         {
           description:
             'Query blocks by hash or height, list recent blocks, and retrieve 24-hour block production statistics.',
-          name: 'V3 / Blocks',
+          name: 'Blocks',
         },
         {
           description:
             'Look up fungible token contracts, list top tokens, and paginate through transfer history and holder data.',
-          name: 'V3 / FTs',
+          name: 'FTs',
         },
         {
           description:
             'Look up account information associated with a public access key.',
-          name: 'V3 / Keys',
+          name: 'Keys',
         },
         {
           description:
             'Query chain-signature multichain transactions and daily signing statistics.',
-          name: 'V3 / Multichain',
+          name: 'Multichain',
         },
         {
           description:
             'Look up NFT contracts and individual tokens, list top collections, and paginate through transfer history and holder data.',
-          name: 'V3 / NFTs',
+          name: 'NFTs',
         },
         {
           description:
             'Search across transactions, blocks, accounts, receipts, and tokens by hash, height, ID, or address.',
-          name: 'V3 / Search',
+          name: 'Search',
         },
         {
           description:
             'Network-wide statistics including supply, gas usage, active accounts, and daily aggregates.',
-          name: 'V3 / Stats',
+          name: 'Stats',
         },
         {
           description:
             'List and filter transactions, retrieve transaction details with receipts, and inspect associated token events.',
-          name: 'V3 / Txns',
-        },
-        // ── Legacy (v1/v2) — deprecated, will be removed ─────────────
-        {
-          description: 'Deprecated. These endpoints will be removed.',
-          name: 'Legacy / Account',
-        },
-        {
-          description: 'Deprecated. These endpoints will be removed.',
-          name: 'Legacy / Access Keys',
-        },
-        {
-          description: 'Deprecated. These endpoints will be removed.',
-          name: 'Legacy / Blocks',
-        },
-        {
-          description: 'Deprecated. These endpoints will be removed.',
-          name: 'Legacy / Chain Abstraction',
-        },
-        {
-          description: 'Deprecated. These endpoints will be removed.',
-          name: 'Legacy / Charts',
-        },
-        {
-          description: 'Deprecated. These endpoints will be removed.',
-          name: 'Legacy / DEX',
-        },
-        {
-          description: 'Deprecated. These endpoints will be removed.',
-          name: 'Legacy / FTs',
-        },
-        {
-          description: 'Deprecated. These endpoints will be removed.',
-          name: 'Legacy / Kitwallet',
-        },
-        {
-          description: 'Deprecated. These endpoints will be removed.',
-          name: 'Legacy / Supply',
-        },
-        {
-          description: 'Deprecated. These endpoints will be removed.',
-          name: 'Legacy / NFTs',
-        },
-        {
-          description: 'Deprecated. These endpoints will be removed.',
-          name: 'Legacy / Search',
-        },
-        {
-          description: 'Deprecated. These endpoints will be removed.',
-          name: 'Legacy / Stats',
-        },
-        {
-          description: 'Deprecated. These endpoints will be removed.',
-          name: 'Legacy / Txns',
-        },
-        {
-          description: 'Deprecated. These endpoints will be removed.',
-          name: 'Legacy / Validators',
-        },
-        {
-          description: 'Deprecated. These endpoints will be removed.',
-          name: 'Legacy / V2 Account',
-        },
-        {
-          description:
-            'V2 transaction endpoints. Use V3 / Txns for new integrations.',
-          name: 'Legacy / V2 Txns',
-        },
-      ],
-      'x-tagGroups': [
-        {
-          name: 'API',
-          tags: [
-            'V3 / Accounts',
-            'V3 / Blocks',
-            'V3 / FTs',
-            'V3 / Keys',
-            'V3 / Multichain',
-            'V3 / NFTs',
-            'V3 / Search',
-            'V3 / Stats',
-            'V3 / Txns',
-          ],
-        },
-        {
-          name: 'Legacy (Deprecated)',
-          tags: [
-            'Legacy / Account',
-            'Legacy / Access Keys',
-            'Legacy / Blocks',
-            'Legacy / Chain Abstraction',
-            'Legacy / Charts',
-            'Legacy / DEX',
-            'Legacy / FTs',
-            'Legacy / Kitwallet',
-            'Legacy / Supply',
-            'Legacy / NFTs',
-            'Legacy / Search',
-            'Legacy / Stats',
-            'Legacy / Txns',
-            'Legacy / Validators',
-            'Legacy / V2 Account',
-            'Legacy / V2 Txns',
-          ],
+          name: 'Txns',
         },
       ],
     },
   };
 
-  const openapiSpecification = swaggerJsdoc(options);
+  // ── Legacy API docs (v1/v2) ───────���───────────────────────────────
+  const legacyOptions = {
+    apis: [
+      path.join(dir, 'routes/*.{ts,js}'),
+      path.join(dir, 'routes/v2/**/*.{ts,js}'),
+    ],
+    definition: {
+      components: {
+        securitySchemes: {
+          BearerAuth: {
+            scheme: 'bearer',
+            type: 'http',
+          },
+        },
+      },
+      info: {
+        description: `<p><strong>These are deprecated endpoints. They will be removed in a future release.</strong></p>
+        <p>For new integrations, use the <a href="/api-docs">current API</a>.</p>
+        `,
+        title: ' ',
+        version: '1.0.0',
+      },
+      openapi: '3.0.0',
+      servers,
+      tags: [
+        { description: 'Deprecated.', name: 'Legacy / Account' },
+        { description: 'Deprecated.', name: 'Legacy / Access Keys' },
+        { description: 'Deprecated.', name: 'Legacy / Blocks' },
+        { description: 'Deprecated.', name: 'Legacy / Chain Abstraction' },
+        { description: 'Deprecated.', name: 'Legacy / Charts' },
+        { description: 'Deprecated.', name: 'Legacy / DEX' },
+        { description: 'Deprecated.', name: 'Legacy / FTs' },
+        { description: 'Deprecated.', name: 'Legacy / Kitwallet' },
+        { description: 'Deprecated.', name: 'Legacy / Supply' },
+        { description: 'Deprecated.', name: 'Legacy / NFTs' },
+        { description: 'Deprecated.', name: 'Legacy / Search' },
+        { description: 'Deprecated.', name: 'Legacy / Stats' },
+        { description: 'Deprecated.', name: 'Legacy / Txns' },
+        { description: 'Deprecated.', name: 'Legacy / Validators' },
+        { description: 'Deprecated.', name: 'Legacy / V2 Account' },
+        { description: 'Deprecated.', name: 'Legacy / V2 Txns' },
+      ],
+    },
+  };
+
+  const mainSpec = swaggerJsdoc(mainOptions);
+  const legacySpec = swaggerJsdoc(legacyOptions);
 
   app.get('/openapi.json', (_, res) => {
-    res.json(openapiSpecification);
+    res.json(mainSpec);
   });
+
+  app.get('/openapi-legacy.json', (_, res) => {
+    res.json(legacySpec);
+  });
+
+  app.use(
+    '/api-docs/legacy',
+    apiReference({
+      customCss: scalarCss,
+      documentDownloadType: 'none',
+      favicon: 'https://nearblocks.io/favicon_32x32.png',
+      layout: 'modern',
+      metaData: scalarMeta,
+      theme: 'none',
+      url: '/openapi-legacy.json',
+    }),
+  );
 
   app.use(
     '/api-docs',
     apiReference({
-      customCss: `
-         .light-mode .introduction-section {
-          background: url(https://nearblocks.io/images/nearblocksblack.svg) no-repeat;
-          background-size: auto;
-          padding-top: 60px;
-          margin-top: 12px;
-        }
-        
-        .dark-mode .introduction-section {
-          background: url(https://nearblocks.io/images/nearblocksblack_dark.svg) no-repeat;
-          background-size: auto;
-          padding-top: 60px;
-          margin-top: 12px;
-        }
-          
-      `,
+      customCss: scalarCss,
       documentDownloadType: 'none',
       favicon: 'https://nearblocks.io/favicon_32x32.png',
       layout: 'modern',
-      metaData: {
-        description:
-          'NearBlocks REST API documentation for the NEAR Protocol. Provides endpoints to access blockchain data and integrate seamlessly with NEAR.',
-        ogDescription:
-          'NearBlocks REST API documentation for the NEAR Protocol. Provides endpoints to access blockchain data and integrate seamlessly with NEAR.',
-        ogTitle: 'Near(Ⓝ) REST API | NearBlocks',
-        title: 'Near(Ⓝ) REST API | NearBlocks',
-        twitterDescription:
-          'NearBlocks REST API documentation for the NEAR Protocol. Provides endpoints to access blockchain data and integrate seamlessly with NEAR.',
-        twitterTitle: 'Near(Ⓝ) REST API | NearBlocks',
-      },
+      metaData: scalarMeta,
       theme: 'none',
       url: '/openapi.json',
     }),

--- a/apps/api/src/routes/v3/accounts/account.ts
+++ b/apps/api/src/routes/v3/accounts/account.ts
@@ -12,7 +12,7 @@ const routes = (route: Router) => {
    *   get:
    *     summary: Get account details
    *     tags:
-   *       - V3 / Accounts
+   *       - Accounts
    *     parameters:
    *       - in: path
    *         name: account
@@ -32,7 +32,7 @@ const routes = (route: Router) => {
    *   get:
    *     summary: Get account balance
    *     tags:
-   *       - V3 / Accounts
+   *       - Accounts
    *     parameters:
    *       - in: path
    *         name: account

--- a/apps/api/src/routes/v3/accounts/assets.ts
+++ b/apps/api/src/routes/v3/accounts/assets.ts
@@ -13,7 +13,7 @@ const routes = (route: Router) => {
    *   get:
    *     summary: List account FT balances
    *     tags:
-   *       - V3 / Accounts
+   *       - Accounts
    *     parameters:
    *       - in: path
    *         name: account
@@ -52,7 +52,7 @@ const routes = (route: Router) => {
    *     summary: Get account FT balances count
    *     x-internal: true
    *     tags:
-   *       - V3 / Accounts
+   *       - Accounts
    *     parameters:
    *       - in: path
    *         name: account
@@ -77,7 +77,7 @@ const routes = (route: Router) => {
    *   get:
    *     summary: List account NFT balances
    *     tags:
-   *       - V3 / Accounts
+   *       - Accounts
    *     parameters:
    *       - in: path
    *         name: account
@@ -116,7 +116,7 @@ const routes = (route: Router) => {
    *     summary: Get account NFT balances count
    *     x-internal: true
    *     tags:
-   *       - V3 / Accounts
+   *       - Accounts
    *     parameters:
    *       - in: path
    *         name: account

--- a/apps/api/src/routes/v3/accounts/contract.ts
+++ b/apps/api/src/routes/v3/accounts/contract.ts
@@ -12,7 +12,7 @@ const routes = (route: Router) => {
    *   get:
    *     summary: Get contract metadata
    *     tags:
-   *       - V3 / Accounts
+   *       - Accounts
    *     parameters:
    *       - in: path
    *         name: contract
@@ -36,7 +36,7 @@ const routes = (route: Router) => {
    *   get:
    *     summary: Get contract deployment history
    *     tags:
-   *       - V3 / Accounts
+   *       - Accounts
    *     parameters:
    *       - in: path
    *         name: contract
@@ -60,7 +60,7 @@ const routes = (route: Router) => {
    *   get:
    *     summary: Get contract ABI schema
    *     tags:
-   *       - V3 / Accounts
+   *       - Accounts
    *     parameters:
    *       - in: path
    *         name: contract
@@ -84,7 +84,7 @@ const routes = (route: Router) => {
    *   get:
    *     summary: Get latest action args for a contract method
    *     tags:
-   *       - V3 / Accounts
+   *       - Accounts
    *     parameters:
    *       - in: path
    *         name: contract

--- a/apps/api/src/routes/v3/accounts/fts.ts
+++ b/apps/api/src/routes/v3/accounts/fts.ts
@@ -13,7 +13,7 @@ const routes = (route: Router) => {
    *   get:
    *     summary: List account FT transfers
    *     tags:
-   *       - V3 / Accounts
+   *       - Accounts
    *     parameters:
    *       - in: path
    *         name: account
@@ -69,7 +69,7 @@ const routes = (route: Router) => {
    *     summary: Get estimated account FT transfer count
    *     x-internal: true
    *     tags:
-   *       - V3 / Accounts
+   *       - Accounts
    *     parameters:
    *       - in: path
    *         name: account

--- a/apps/api/src/routes/v3/accounts/keys.ts
+++ b/apps/api/src/routes/v3/accounts/keys.ts
@@ -13,7 +13,7 @@ const routes = (route: Router) => {
    *   get:
    *     summary: List account access keys
    *     tags:
-   *       - V3 / Accounts
+   *       - Accounts
    *     parameters:
    *       - in: path
    *         name: account
@@ -52,7 +52,7 @@ const routes = (route: Router) => {
    *     summary: Get account access key count
    *     x-internal: true
    *     tags:
-   *       - V3 / Accounts
+   *       - Accounts
    *     parameters:
    *       - in: path
    *         name: account

--- a/apps/api/src/routes/v3/accounts/mts.ts
+++ b/apps/api/src/routes/v3/accounts/mts.ts
@@ -13,7 +13,7 @@ const routes = (route: Router) => {
    *   get:
    *     summary: List account multi-token transfers
    *     tags:
-   *       - V3 / Accounts
+   *       - Accounts
    *     parameters:
    *       - in: path
    *         name: account
@@ -74,7 +74,7 @@ const routes = (route: Router) => {
    *     summary: Get estimated account multi-token transfer count
    *     x-internal: true
    *     tags:
-   *       - V3 / Accounts
+   *       - Accounts
    *     parameters:
    *       - in: path
    *         name: account

--- a/apps/api/src/routes/v3/accounts/nfts.ts
+++ b/apps/api/src/routes/v3/accounts/nfts.ts
@@ -13,7 +13,7 @@ const routes = (route: Router) => {
    *   get:
    *     summary: List account NFT transfers
    *     tags:
-   *       - V3 / Accounts
+   *       - Accounts
    *     parameters:
    *       - in: path
    *         name: account
@@ -74,7 +74,7 @@ const routes = (route: Router) => {
    *     summary: Get estimated account NFT transfer count
    *     x-internal: true
    *     tags:
-   *       - V3 / Accounts
+   *       - Accounts
    *     parameters:
    *       - in: path
    *         name: account

--- a/apps/api/src/routes/v3/accounts/receipts.ts
+++ b/apps/api/src/routes/v3/accounts/receipts.ts
@@ -13,7 +13,7 @@ const routes = (route: Router) => {
    *   get:
    *     summary: List account receipts
    *     tags:
-   *       - V3 / Accounts
+   *       - Accounts
    *     parameters:
    *       - in: path
    *         name: account
@@ -79,7 +79,7 @@ const routes = (route: Router) => {
    *     summary: Get estimated account receipt count
    *     x-internal: true
    *     tags:
-   *       - V3 / Accounts
+   *       - Accounts
    *     parameters:
    *       - in: path
    *         name: account

--- a/apps/api/src/routes/v3/accounts/staking.ts
+++ b/apps/api/src/routes/v3/accounts/staking.ts
@@ -13,7 +13,7 @@ const routes = (route: Router) => {
    *   get:
    *     summary: List account staking transactions
    *     tags:
-   *       - V3 / Accounts
+   *       - Accounts
    *     parameters:
    *       - in: path
    *         name: account
@@ -64,7 +64,7 @@ const routes = (route: Router) => {
    *     summary: Get estimated account staking transaction count
    *     x-internal: true
    *     tags:
-   *       - V3 / Accounts
+   *       - Accounts
    *     parameters:
    *       - in: path
    *         name: account

--- a/apps/api/src/routes/v3/accounts/stats.ts
+++ b/apps/api/src/routes/v3/accounts/stats.ts
@@ -12,7 +12,7 @@ const routes = (route: Router) => {
    *   get:
    *     summary: Get account statistics overview
    *     tags:
-   *       - V3 / Accounts
+   *       - Accounts
    *     parameters:
    *       - in: path
    *         name: account
@@ -31,7 +31,7 @@ const routes = (route: Router) => {
    *   get:
    *     summary: Get account transaction heatmap
    *     tags:
-   *       - V3 / Accounts
+   *       - Accounts
    *     parameters:
    *       - in: path
    *         name: account
@@ -55,7 +55,7 @@ const routes = (route: Router) => {
    *   get:
    *     summary: Get account transaction statistics
    *     tags:
-   *       - V3 / Accounts
+   *       - Accounts
    *     parameters:
    *       - in: path
    *         name: account
@@ -82,7 +82,7 @@ const routes = (route: Router) => {
    *   get:
    *     summary: Get account balance history
    *     tags:
-   *       - V3 / Accounts
+   *       - Accounts
    *     parameters:
    *       - in: path
    *         name: account
@@ -113,7 +113,7 @@ const routes = (route: Router) => {
    *   get:
    *     summary: Get account NEAR statistics
    *     tags:
-   *       - V3 / Accounts
+   *       - Accounts
    *     parameters:
    *       - in: path
    *         name: account
@@ -140,7 +140,7 @@ const routes = (route: Router) => {
    *   get:
    *     summary: Get account FT statistics
    *     tags:
-   *       - V3 / Accounts
+   *       - Accounts
    *     parameters:
    *       - in: path
    *         name: account

--- a/apps/api/src/routes/v3/accounts/txns.ts
+++ b/apps/api/src/routes/v3/accounts/txns.ts
@@ -13,7 +13,7 @@ const routes = (route: Router) => {
    *   get:
    *     summary: List account transactions
    *     tags:
-   *       - V3 / Accounts
+   *       - Accounts
    *     parameters:
    *       - in: path
    *         name: account
@@ -69,7 +69,7 @@ const routes = (route: Router) => {
    *     summary: Get estimated account transaction count
    *     x-internal: true
    *     tags:
-   *       - V3 / Accounts
+   *       - Accounts
    *     parameters:
    *       - in: path
    *         name: account

--- a/apps/api/src/routes/v3/blocks.ts
+++ b/apps/api/src/routes/v3/blocks.ts
@@ -19,7 +19,7 @@ const routes = (app: Router) => {
    *   get:
    *     summary: List blocks
    *     tags:
-   *       - V3 / Blocks
+   *       - Blocks
    *     parameters:
    *       - in: query
    *         name: next
@@ -52,7 +52,7 @@ const routes = (app: Router) => {
    *     summary: Get estimated block count
    *     x-internal: true
    *     tags:
-   *       - V3 / Blocks
+   *       - Blocks
    *     responses:
    *       200:
    *         description: Success response
@@ -66,7 +66,7 @@ const routes = (app: Router) => {
    *     summary: List latest blocks
    *     description: ⚠️ Response is cached for 5 seconds
    *     tags:
-   *       - V3 / Blocks
+   *       - Blocks
    *     parameters:
    *       - in: query
    *         name: limit
@@ -88,7 +88,7 @@ const routes = (app: Router) => {
    *   get:
    *     summary: Get 24-hour block statistics
    *     tags:
-   *       - V3 / Blocks
+   *       - Blocks
    *     responses:
    *       200:
    *         description: Success response
@@ -101,7 +101,7 @@ const routes = (app: Router) => {
    *   get:
    *     summary: Get block by hash
    *     tags:
-   *       - V3 / Blocks
+   *       - Blocks
    *     parameters:
    *       - in: path
    *         name: hash

--- a/apps/api/src/routes/v3/fts/contract.ts
+++ b/apps/api/src/routes/v3/fts/contract.ts
@@ -18,7 +18,7 @@ const routes = (app: Router) => {
    *   get:
    *     summary: Get FT contract details
    *     tags:
-   *       - V3 / FTs
+   *       - FTs
    *     parameters:
    *       - in: path
    *         name: contract
@@ -38,7 +38,7 @@ const routes = (app: Router) => {
    *   get:
    *     summary: List FT contract transfers
    *     tags:
-   *       - V3 / FTs
+   *       - FTs
    *     parameters:
    *       - in: path
    *         name: contract
@@ -88,7 +88,7 @@ const routes = (app: Router) => {
    *   get:
    *     summary: Get FT contract transfer count
    *     tags:
-   *       - V3 / FTs
+   *       - FTs
    *     parameters:
    *       - in: path
    *         name: contract
@@ -124,7 +124,7 @@ const routes = (app: Router) => {
    *   get:
    *     summary: List FT contract holders
    *     tags:
-   *       - V3 / FTs
+   *       - FTs
    *     parameters:
    *       - in: path
    *         name: contract
@@ -166,7 +166,7 @@ const routes = (app: Router) => {
    *   get:
    *     summary: Get FT contract holder count
    *     tags:
-   *       - V3 / FTs
+   *       - FTs
    *     parameters:
    *       - in: path
    *         name: contract

--- a/apps/api/src/routes/v3/fts/index.ts
+++ b/apps/api/src/routes/v3/fts/index.ts
@@ -22,7 +22,7 @@ const routes = (app: Router) => {
    *   get:
    *     summary: List top fungible tokens
    *     tags:
-   *       - V3 / FTs
+   *       - FTs
    *     parameters:
    *       - in: query
    *         name: search
@@ -74,7 +74,7 @@ const routes = (app: Router) => {
    *     summary: Get fungible token count
    *     x-internal: true
    *     tags:
-   *       - V3 / FTs
+   *       - FTs
    *     parameters:
    *       - in: query
    *         name: search
@@ -93,7 +93,7 @@ const routes = (app: Router) => {
    *   get:
    *     summary: List all FT transfers
    *     tags:
-   *       - V3 / FTs
+   *       - FTs
    *     parameters:
    *       - in: query
    *         name: before_ts
@@ -133,7 +133,7 @@ const routes = (app: Router) => {
    *     summary: Get FT transfer count
    *     x-internal: true
    *     tags:
-   *       - V3 / FTs
+   *       - FTs
    *     parameters:
    *       - in: query
    *         name: before_ts

--- a/apps/api/src/routes/v3/keys.ts
+++ b/apps/api/src/routes/v3/keys.ts
@@ -18,7 +18,7 @@ const routes = (app: Router) => {
    *   get:
    *     summary: Get access key info
    *     tags:
-   *       - V3 / Keys
+   *       - Keys
    *     parameters:
    *       - in: path
    *         name: key

--- a/apps/api/src/routes/v3/multichain/signatures.ts
+++ b/apps/api/src/routes/v3/multichain/signatures.ts
@@ -19,7 +19,7 @@ const routes = (app: Router) => {
    *   get:
    *     summary: List multichain signature transactions
    *     tags:
-   *       - V3 / Multichain
+   *       - Multichain
    *     parameters:
    *       - in: query
    *         name: account
@@ -80,7 +80,7 @@ const routes = (app: Router) => {
    *     summary: Get estimated multichain signature count
    *     x-internal: true
    *     tags:
-   *       - V3 / Multichain
+   *       - Multichain
    *     parameters:
    *       - in: query
    *         name: account
@@ -127,7 +127,7 @@ const routes = (app: Router) => {
    *   get:
    *     summary: Get 24-hour multichain signature statistics
    *     tags:
-   *       - V3 / Multichain
+   *       - Multichain
    *     responses:
    *       200:
    *         description: Success response

--- a/apps/api/src/routes/v3/nfts/contract.ts
+++ b/apps/api/src/routes/v3/nfts/contract.ts
@@ -18,7 +18,7 @@ const routes = (app: Router) => {
    *   get:
    *     summary: Get NFT contract details
    *     tags:
-   *       - V3 / NFTs
+   *       - NFTs
    *     parameters:
    *       - in: path
    *         name: contract
@@ -38,7 +38,7 @@ const routes = (app: Router) => {
    *   get:
    *     summary: List NFT contract transfers
    *     tags:
-   *       - V3 / NFTs
+   *       - NFTs
    *     parameters:
    *       - in: path
    *         name: contract
@@ -88,7 +88,7 @@ const routes = (app: Router) => {
    *   get:
    *     summary: Get NFT contract transfer count
    *     tags:
-   *       - V3 / NFTs
+   *       - NFTs
    *     parameters:
    *       - in: path
    *         name: contract
@@ -124,7 +124,7 @@ const routes = (app: Router) => {
    *   get:
    *     summary: List NFT contract holders
    *     tags:
-   *       - V3 / NFTs
+   *       - NFTs
    *     parameters:
    *       - in: path
    *         name: contract
@@ -166,7 +166,7 @@ const routes = (app: Router) => {
    *   get:
    *     summary: Get NFT contract holder count
    *     tags:
-   *       - V3 / NFTs
+   *       - NFTs
    *     parameters:
    *       - in: path
    *         name: contract

--- a/apps/api/src/routes/v3/nfts/index.ts
+++ b/apps/api/src/routes/v3/nfts/index.ts
@@ -24,7 +24,7 @@ const routes = (app: Router) => {
    *   get:
    *     summary: List top NFT collections
    *     tags:
-   *       - V3 / NFTs
+   *       - NFTs
    *     parameters:
    *       - in: query
    *         name: search
@@ -76,7 +76,7 @@ const routes = (app: Router) => {
    *     summary: Get NFT collection count
    *     x-internal: true
    *     tags:
-   *       - V3 / NFTs
+   *       - NFTs
    *     parameters:
    *       - in: query
    *         name: search
@@ -95,7 +95,7 @@ const routes = (app: Router) => {
    *   get:
    *     summary: List all NFT transfers
    *     tags:
-   *       - V3 / NFTs
+   *       - NFTs
    *     parameters:
    *       - in: query
    *         name: before_ts
@@ -135,7 +135,7 @@ const routes = (app: Router) => {
    *     summary: Get NFT transfer count
    *     x-internal: true
    *     tags:
-   *       - V3 / NFTs
+   *       - NFTs
    *     parameters:
    *       - in: query
    *         name: before_ts

--- a/apps/api/src/routes/v3/nfts/token.ts
+++ b/apps/api/src/routes/v3/nfts/token.ts
@@ -18,7 +18,7 @@ const routes = (app: Router) => {
    *   get:
    *     summary: List NFT tokens in a contract
    *     tags:
-   *       - V3 / NFTs
+   *       - NFTs
    *     parameters:
    *       - in: path
    *         name: contract
@@ -56,7 +56,7 @@ const routes = (app: Router) => {
    *   get:
    *     summary: Get NFT token count in a contract
    *     tags:
-   *       - V3 / NFTs
+   *       - NFTs
    *     parameters:
    *       - in: path
    *         name: contract
@@ -80,7 +80,7 @@ const routes = (app: Router) => {
    *   get:
    *     summary: Get NFT token details
    *     tags:
-   *       - V3 / NFTs
+   *       - NFTs
    *     parameters:
    *       - in: path
    *         name: contract
@@ -106,7 +106,7 @@ const routes = (app: Router) => {
    *   get:
    *     summary: List NFT token transfers
    *     tags:
-   *       - V3 / NFTs
+   *       - NFTs
    *     parameters:
    *       - in: path
    *         name: contract
@@ -161,7 +161,7 @@ const routes = (app: Router) => {
    *   get:
    *     summary: Get NFT token transfer count
    *     tags:
-   *       - V3 / NFTs
+   *       - NFTs
    *     parameters:
    *       - in: path
    *         name: contract

--- a/apps/api/src/routes/v3/search.ts
+++ b/apps/api/src/routes/v3/search.ts
@@ -18,7 +18,7 @@ const routes = (app: Router) => {
    *   get:
    *     summary: Search all entities
    *     tags:
-   *       - V3 / Search
+   *       - Search
    *     parameters:
    *       - in: query
    *         name: keyword
@@ -37,7 +37,7 @@ const routes = (app: Router) => {
    *   get:
    *     summary: Search accounts
    *     tags:
-   *       - V3 / Search
+   *       - Search
    *     parameters:
    *       - in: query
    *         name: keyword
@@ -56,7 +56,7 @@ const routes = (app: Router) => {
    *   get:
    *     summary: Search blocks
    *     tags:
-   *       - V3 / Search
+   *       - Search
    *     parameters:
    *       - in: query
    *         name: keyword
@@ -75,7 +75,7 @@ const routes = (app: Router) => {
    *   get:
    *     summary: Search access keys
    *     tags:
-   *       - V3 / Search
+   *       - Search
    *     parameters:
    *       - in: query
    *         name: keyword
@@ -94,7 +94,7 @@ const routes = (app: Router) => {
    *   get:
    *     summary: Search fungible tokens
    *     tags:
-   *       - V3 / Search
+   *       - Search
    *     parameters:
    *       - in: query
    *         name: keyword
@@ -113,7 +113,7 @@ const routes = (app: Router) => {
    *   get:
    *     summary: Search NFTs
    *     tags:
-   *       - V3 / Search
+   *       - Search
    *     parameters:
    *       - in: query
    *         name: keyword
@@ -132,7 +132,7 @@ const routes = (app: Router) => {
    *   get:
    *     summary: Search receipts
    *     tags:
-   *       - V3 / Search
+   *       - Search
    *     parameters:
    *       - in: query
    *         name: keyword
@@ -151,7 +151,7 @@ const routes = (app: Router) => {
    *   get:
    *     summary: Search transactions
    *     tags:
-   *       - V3 / Search
+   *       - Search
    *     parameters:
    *       - in: query
    *         name: keyword

--- a/apps/api/src/routes/v3/stats.ts
+++ b/apps/api/src/routes/v3/stats.ts
@@ -14,7 +14,7 @@ const routes = (app: Router) => {
    *   get:
    *     summary: Get network statistics
    *     tags:
-   *       - V3 / Stats
+   *       - Stats
    *     responses:
    *       200:
    *         description: Success response
@@ -27,7 +27,7 @@ const routes = (app: Router) => {
    *   get:
    *     summary: Get daily network statistics
    *     tags:
-   *       - V3 / Stats
+   *       - Stats
    *     parameters:
    *       - in: query
    *         name: limit
@@ -57,7 +57,7 @@ const routes = (app: Router) => {
    *   get:
    *     summary: Get transactions-per-second statistics
    *     tags:
-   *       - V3 / Stats
+   *       - Stats
    *     responses:
    *       200:
    *         description: Success response

--- a/apps/api/src/routes/v3/txns.ts
+++ b/apps/api/src/routes/v3/txns.ts
@@ -19,7 +19,7 @@ const routes = (app: Router) => {
    *   get:
    *     summary: List transactions
    *     tags:
-   *       - V3 / Txns
+   *       - Txns
    *     parameters:
    *       - in: query
    *         name: block
@@ -64,7 +64,7 @@ const routes = (app: Router) => {
    *     summary: Get estimated transaction count
    *     x-internal: true
    *     tags:
-   *       - V3 / Txns
+   *       - Txns
    *     parameters:
    *       - in: query
    *         name: block
@@ -99,7 +99,7 @@ const routes = (app: Router) => {
    *     summary: List latest transactions
    *     description: ⚠️ Response is cached for 5 seconds
    *     tags:
-   *       - V3 / Txns
+   *       - Txns
    *     parameters:
    *       - in: query
    *         name: limit
@@ -121,7 +121,7 @@ const routes = (app: Router) => {
    *   get:
    *     summary: Get 24-hour transaction statistics
    *     tags:
-   *       - V3 / Txns
+   *       - Txns
    *     responses:
    *       200:
    *         description: Success response
@@ -134,7 +134,7 @@ const routes = (app: Router) => {
    *   get:
    *     summary: Get transaction by hash
    *     tags:
-   *       - V3 / Txns
+   *       - Txns
    *     parameters:
    *       - in: path
    *         name: hash
@@ -154,7 +154,7 @@ const routes = (app: Router) => {
    *   get:
    *     summary: List transaction receipts
    *     tags:
-   *       - V3 / Txns
+   *       - Txns
    *     parameters:
    *       - in: path
    *         name: hash
@@ -174,7 +174,7 @@ const routes = (app: Router) => {
    *   get:
    *     summary: List transaction FT events
    *     tags:
-   *       - V3 / Txns
+   *       - Txns
    *     parameters:
    *       - in: path
    *         name: hash
@@ -194,7 +194,7 @@ const routes = (app: Router) => {
    *   get:
    *     summary: List transaction NFT events
    *     tags:
-   *       - V3 / Txns
+   *       - Txns
    *     parameters:
    *       - in: path
    *         name: hash
@@ -214,7 +214,7 @@ const routes = (app: Router) => {
    *   get:
    *     summary: List transaction multi-token events
    *     tags:
-   *       - V3 / Txns
+   *       - Txns
    *     parameters:
    *       - in: path
    *         name: hash


### PR DESCRIPTION
- Main docs at /api-docs serve only V3 endpoints with clean tag names
- Legacy docs at /api-docs/legacy serve deprecated v1/v2 endpoints
- Drop "V3 / " prefix from all V3 tags for cleaner navigation
- Add link to legacy docs in main API description
