### PR TITLE
fix(backend): disable ref finance price sync

### DIFF
--- a/apps/backend/src/jobs/tokenMarket.ts
+++ b/apps/backend/src/jobs/tokenMarket.ts
@@ -1,14 +1,13 @@
 import { logger } from 'nb-logger';
 
 import sentry from '#libs/sentry';
-import { syncFTData, syncFTPrice } from '#services/fts/market';
+import { syncFTData } from '#services/fts/market';
 import { syncMTPrice } from '#services/mts/market';
 
 export const task = async () => {
   try {
     logger.info('tokenMarket: job started');
     await syncFTData();
-    await syncFTPrice();
     await syncMTPrice();
     logger.info('tokenMarket: job ended');
   } catch (error) {

--- a/apps/backend/src/services/fts/market.ts
+++ b/apps/backend/src/services/fts/market.ts
@@ -8,7 +8,6 @@ import cg from '#libs/cg';
 import cmc from '#libs/cmc';
 import dayjs from '#libs/dayjs';
 import { dbEvents } from '#libs/knex';
-import ref from '#libs/ref';
 import { MetaContract, Raw } from '#types/types';
 
 export const syncFTData = async () => {
@@ -32,39 +31,6 @@ export const syncFTData = async () => {
   );
 
   await Promise.all(fts.map((ft) => updateFTData(ft.contract)));
-};
-
-export const syncFTPrice = async () => {
-  if (config.network === Network.TESTNET) {
-    return;
-  }
-
-  const data = await ref.price();
-
-  if (!data) {
-    return;
-  }
-
-  const keys = Object.keys(data);
-  const values = keys.map(() => `(?, ?)`).join(',');
-  const bindings = keys.flatMap((key) => [key, data[key].price]);
-
-  await dbEvents.raw(
-    `
-      UPDATE ft_meta AS t
-      SET
-        price = v.price::numeric,
-        refreshed_at = now()
-      FROM
-        (
-          VALUES
-            ${values}
-        ) AS v (contract, price)
-      WHERE
-        t.contract = v.contract
-    `,
-    bindings,
-  );
 };
 
 const updateFTData = async (contract: string) => {


### PR DESCRIPTION
## Summary
- Remove Ref Finance as FT price source — their indexer returns incorrect prices (e.g. USDC at $36037 instead of ~$1)
- Price sync now relies solely on CoinGecko and CoinMarketCap
- Removes `syncFTPrice` function and ref import from market service

## Test plan
- [x] Verified fix on `backend` branch (deployed, USDC price corrected to $0.9998 via CG/CMC)
- [ ] Confirm no regression in other token prices after deploy