### PR TITLE
feat(block-proxy): log and track 429 responses from fastnear upstream

### DIFF
--- a/apps/block-proxy/package.json
+++ b/apps/block-proxy/package.json
@@ -27,6 +27,7 @@
   "devDependencies": {
     "@types/express": "~4.17",
     "@types/node": "~20.8",
+    "@types/uuid": "~10.0",
     "nb-logger": "*",
     "nb-tsconfig": "*",
     "rimraf": "~5.0",

--- a/apps/block-proxy/src/cache/index.ts
+++ b/apps/block-proxy/src/cache/index.ts
@@ -160,7 +160,7 @@ export class CacheStore {
     );
 
     try {
-      await fsp.writeFile(tmpPath, jsonBytes);
+      await fsp.writeFile(tmpPath, new Uint8Array(jsonBytes));
       await fsp.rename(tmpPath, filePath);
       logger.debug({ bytes: jsonBytes.length, height }, 'cache write complete');
     } catch (err) {

--- a/apps/block-proxy/src/metrics.ts
+++ b/apps/block-proxy/src/metrics.ts
@@ -59,6 +59,13 @@ export const upstreamDuration = new client.Histogram({
   registers: [register],
 });
 
+export const upstreamRateLimited = new client.Counter({
+  help: 'Total upstream rate-limited (HTTP 429) response count by source',
+  labelNames: ['source'] as const,
+  name: 'block_proxy_upstream_rate_limited',
+  registers: [register],
+});
+
 export const tipHeight = new client.Gauge({
   help: 'Latest known chain tip height',
   name: 'block_proxy_tip_height',

--- a/apps/block-proxy/src/upstream/fastnear.ts
+++ b/apps/block-proxy/src/upstream/fastnear.ts
@@ -1,6 +1,7 @@
 import { logger } from 'nb-logger';
 
 import type { Config } from '#config';
+import * as metrics from '#metrics';
 
 const MAX_BODY_SIZE = 100 * 1024 * 1024; // 100 MB
 
@@ -36,6 +37,20 @@ export class FastnearUpstream {
       ) as Error & { notFound: boolean };
       err.notFound = true;
       throw err;
+    }
+
+    if (response.status === 429) {
+      metrics.upstreamRateLimited.inc({ source: 'fastnear' });
+      logger.warn(
+        {
+          height,
+          latency_ms: Date.now() - start,
+          retry_after: response.headers.get('retry-after'),
+          source: 'fastnear',
+          status: 429,
+        },
+        'fastnear upstream rate limited',
+      );
     }
 
     if (!response.ok) {
@@ -85,6 +100,19 @@ export class FastnearUpstream {
 
     if (response.status === 404) {
       throw new Error('last_block/final not found on fastnear');
+    }
+
+    if (response.status === 429) {
+      metrics.upstreamRateLimited.inc({ source: 'fastnear' });
+      logger.warn(
+        {
+          latency_ms: Date.now() - start,
+          retry_after: response.headers.get('retry-after'),
+          source: 'fastnear',
+          status: 429,
+        },
+        'fastnear upstream rate limited on last_block/final',
+      );
     }
 
     if (!response.ok) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -14757,6 +14757,11 @@
   resolved "https://registry.yarnpkg.com/@types/unist/-/unist-2.0.9.tgz#72e164381659a49557b0a078b28308f2c6a3e1ce"
   integrity sha512-zC0iXxAv1C1ERURduJueYzkzZ2zaGyc+P2c95hgkikHPr3z8EdUZOlgEQ5X0DRmwDZn+hekycQnoeiiRVrmilQ==
 
+"@types/uuid@~10.0":
+  version "10.0.0"
+  resolved "https://registry.yarnpkg.com/@types/uuid/-/uuid-10.0.0.tgz#e9c07fe50da0f53dc24970cca94d619ff03f6f6d"
+  integrity sha512-7gqG38EyHgyP1S+7+xomFtL+ZNHcKv6DwNaCZmJmo1vgMugyF3TCnXVg4t1uk89mLNwnLtnY3TpOpCOyp1/xHQ==
+
 "@types/warning@^3.0.0":
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/@types/warning/-/warning-3.0.2.tgz#264f1f93a68f5dcb598db9764e40f14e13b0e630"
@@ -29843,16 +29848,7 @@ string-length@^4.0.1:
     char-regex "^1.0.2"
     strip-ansi "^6.0.0"
 
-"string-width-cjs@npm:string-width@^4.2.0":
-  version "4.2.3"
-  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
-  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
-  dependencies:
-    emoji-regex "^8.0.0"
-    is-fullwidth-code-point "^3.0.0"
-    strip-ansi "^6.0.1"
-
-"string-width@^1.0.2 || 2 || 3 || 4", string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
+"string-width-cjs@npm:string-width@^4.2.0", "string-width@^1.0.2 || 2 || 3 || 4", string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -29931,14 +29927,7 @@ string_decoder@~1.1.1:
   dependencies:
     safe-buffer "~5.1.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
-  version "6.0.1"
-  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
-  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
-  dependencies:
-    ansi-regex "^5.0.1"
-
-strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -31715,7 +31704,7 @@ wrangler@^3.86.0:
   optionalDependencies:
     fsevents "~2.3.2"
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
@@ -31728,15 +31717,6 @@ wrap-ansi@^6.2.0:
   version "6.2.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-6.2.0.tgz#e9393ba07102e6c91a3b221478f0257cd2856e53"
   integrity sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==
-  dependencies:
-    ansi-styles "^4.0.0"
-    string-width "^4.1.0"
-    strip-ansi "^6.0.0"
-
-wrap-ansi@^7.0.0:
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
-  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
   dependencies:
     ansi-styles "^4.0.0"
     string-width "^4.1.0"


### PR DESCRIPTION
Emit a warn-level log with retry-after on HTTP 429 from neardata/fastnear fetches