### PR TITLE
feat(indexer-multichain): expose per-chain last block timestamp metric

### DIFF
--- a/apps/indexer-multichain/src/libs/prom.ts
+++ b/apps/indexer-multichain/src/libs/prom.ts
@@ -30,4 +30,11 @@ export const chainBlocksProcessed = new client.Counter({
   registers: [register],
 });
 
+export const chainLastBlockTimestamp = new client.Gauge({
+  help: 'Unix timestamp (seconds) of the most recent block processed per chain',
+  labelNames: ['chain'],
+  name: 'multichain_chain_last_block_timestamp_seconds',
+  registers: [register],
+});
+
 export default metrics;

--- a/apps/indexer-multichain/src/services/bitcoin.ts
+++ b/apps/indexer-multichain/src/services/bitcoin.ts
@@ -12,7 +12,11 @@ import {
 } from '#libs/bitcoin';
 import { NotFoundError } from '#libs/errors';
 import { db } from '#libs/knex';
-import { chainBlockHeight, chainBlocksProcessed } from '#libs/prom';
+import {
+  chainBlockHeight,
+  chainBlocksProcessed,
+  chainLastBlockTimestamp,
+} from '#libs/prom';
 import {
   getStartBlock,
   retry,
@@ -91,6 +95,8 @@ const processBlock = async ({ chain, height, interval, url }: BlockProcess) => {
   if (!block) {
     throw new NotFoundError(`${chain}: block not found: ${height}`);
   }
+
+  chainLastBlockTimestamp.set({ chain }, block.timestamp);
 
   if (!block.tx?.length) return;
 

--- a/apps/indexer-multichain/src/services/evm.ts
+++ b/apps/indexer-multichain/src/services/evm.ts
@@ -6,7 +6,11 @@ import config from '#config';
 import { NotFoundError } from '#libs/errors';
 import { getBlock, getLatestBlock, isValid } from '#libs/evm';
 import { db } from '#libs/knex';
-import { chainBlockHeight, chainBlocksProcessed } from '#libs/prom';
+import {
+  chainBlockHeight,
+  chainBlocksProcessed,
+  chainLastBlockTimestamp,
+} from '#libs/prom';
 import {
   getStartBlock,
   retry,
@@ -85,6 +89,8 @@ const processBlock = async ({ chain, height, interval, url }: BlockProcess) => {
   if (!block) {
     throw new NotFoundError(`${chain}: block not found: ${height}`);
   }
+
+  chainLastBlockTimestamp.set({ chain }, parseInt(block.timestamp, 16));
 
   if (!block.transactions?.length) return;
 

--- a/apps/indexer-multichain/src/services/solana.ts
+++ b/apps/indexer-multichain/src/services/solana.ts
@@ -7,7 +7,11 @@ import { sleep } from 'nb-utils';
 import config from '#config';
 import { NotFoundError } from '#libs/errors';
 import { db } from '#libs/knex';
-import { chainBlockHeight, chainBlocksProcessed } from '#libs/prom';
+import {
+  chainBlockHeight,
+  chainBlocksProcessed,
+  chainLastBlockTimestamp,
+} from '#libs/prom';
 import { getBlock, getLatestSlot } from '#libs/solana';
 import {
   getStartBlock,
@@ -88,6 +92,8 @@ const processBlock = async ({ chain, height, interval, url }: BlockProcess) => {
     logger.info(`${chain}: block missing, skipping: ${height}`);
     return;
   }
+
+  chainLastBlockTimestamp.set({ chain }, block.blockTime);
 
   if (!block.transactions?.length) return;
 

--- a/packages/nb-prom/grafana-dashboard.json
+++ b/packages/nb-prom/grafana-dashboard.json
@@ -64,7 +64,7 @@
       "targets": [
         {
           "datasource": { "type": "prometheus", "uid": "${datasource}" },
-          "expr": "time() - max by (indexer) (indexer_last_block_timestamp_seconds{network=~\"$network\", indexer=~\"$indexer\"})",
+          "expr": "time() - max by (indexer) (indexer_last_block_timestamp_seconds{network=~\"$network\", indexer=~\"$indexer\", indexer!=\"multichain\"})",
           "format": "time_series",
           "instant": true,
           "legendFormat": "{{indexer}}",
@@ -202,7 +202,7 @@
         },
         {
           "datasource": { "type": "prometheus", "uid": "${datasource}" },
-          "expr": "time() - max by (indexer) (indexer_last_block_timestamp_seconds{network=~\"$network\", indexer=~\"$indexer\"})",
+          "expr": "time() - max by (indexer) (indexer_last_block_timestamp_seconds{network=~\"$network\", indexer=~\"$indexer\", indexer!=\"multichain\"})",
           "format": "table",
           "instant": true,
           "legendFormat": "",
@@ -352,7 +352,7 @@
       "targets": [
         {
           "datasource": { "type": "prometheus", "uid": "${datasource}" },
-          "expr": "time() - max by (indexer) (indexer_last_block_timestamp_seconds{network=~\"$network\", indexer=~\"$indexer\"})",
+          "expr": "time() - max by (indexer) (indexer_last_block_timestamp_seconds{network=~\"$network\", indexer=~\"$indexer\", indexer!=\"multichain\"})",
           "legendFormat": "{{indexer}}",
           "refId": "A"
         }
@@ -1112,10 +1112,46 @@
           }
         },
         {
+          "id": 19,
+          "title": "Multichain Sync Lag (per chain)",
+          "type": "stat",
+          "gridPos": { "h": 6, "w": 24, "x": 0, "y": 34 },
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "targets": [
+            {
+              "datasource": { "type": "prometheus", "uid": "${datasource}" },
+              "expr": "time() - multichain_chain_last_block_timestamp_seconds{network=~\"$network\", indexer=\"multichain\"}",
+              "legendFormat": "{{chain}}",
+              "refId": "A"
+            }
+          ],
+          "fieldConfig": {
+            "defaults": {
+              "unit": "s",
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  { "color": "green", "value": null },
+                  { "color": "yellow", "value": 120 },
+                  { "color": "orange", "value": 300 },
+                  { "color": "red", "value": 600 }
+                ]
+              }
+            }
+          },
+          "options": {
+            "reduceOptions": { "calcs": ["lastNotNull"] },
+            "textMode": "auto",
+            "colorMode": "background",
+            "graphMode": "none",
+            "orientation": "auto"
+          }
+        },
+        {
           "id": 16,
           "title": "Multichain Blocks Processed (per chain)",
           "type": "timeseries",
-          "gridPos": { "h": 8, "w": 24, "x": 0, "y": 34 },
+          "gridPos": { "h": 8, "w": 24, "x": 0, "y": 40 },
           "datasource": { "type": "prometheus", "uid": "${datasource}" },
           "targets": [
             {
@@ -1142,7 +1178,7 @@
           "id": 18,
           "title": "Multichain Errors",
           "type": "timeseries",
-          "gridPos": { "h": 8, "w": 24, "x": 0, "y": 42 },
+          "gridPos": { "h": 8, "w": 24, "x": 0, "y": 48 },
           "datasource": { "type": "prometheus", "uid": "${datasource}" },
           "targets": [
             {

--- a/packages/nb-prom/grafana-dashboard.json
+++ b/packages/nb-prom/grafana-dashboard.json
@@ -1208,6 +1208,77 @@
           }
         }
       ]
+    },
+    {
+      "collapsed": true,
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 56 },
+      "id": 108,
+      "title": "Block Proxy",
+      "type": "row",
+      "panels": [
+        {
+          "id": 20,
+          "title": "Block Proxy Upstream Rate Limited (429) Rate",
+          "type": "timeseries",
+          "gridPos": { "h": 8, "w": 24, "x": 0, "y": 57 },
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "targets": [
+            {
+              "datasource": { "type": "prometheus", "uid": "${datasource}" },
+              "expr": "rate(block_proxy_upstream_rate_limited[5m])",
+              "legendFormat": "{{source}}",
+              "refId": "A"
+            }
+          ],
+          "fieldConfig": {
+            "defaults": {
+              "unit": "ops",
+              "custom": {
+                "drawStyle": "line",
+                "fillOpacity": 15,
+                "lineWidth": 2,
+                "pointSize": 5,
+                "showPoints": "never"
+              }
+            }
+          }
+        },
+        {
+          "id": 21,
+          "title": "Block Proxy Upstream 429s (1h total)",
+          "type": "stat",
+          "gridPos": { "h": 6, "w": 24, "x": 0, "y": 65 },
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "targets": [
+            {
+              "datasource": { "type": "prometheus", "uid": "${datasource}" },
+              "expr": "increase(block_proxy_upstream_rate_limited[1h])",
+              "legendFormat": "{{source}}",
+              "refId": "A"
+            }
+          ],
+          "fieldConfig": {
+            "defaults": {
+              "unit": "none",
+              "decimals": 0,
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  { "color": "green", "value": null },
+                  { "color": "red", "value": 1 }
+                ]
+              }
+            }
+          },
+          "options": {
+            "reduceOptions": { "calcs": ["lastNotNull"] },
+            "textMode": "auto",
+            "colorMode": "background",
+            "graphMode": "none",
+            "orientation": "auto"
+          }
+        }
+      ]
     }
   ],
   "refresh": "30s",


### PR DESCRIPTION
Adds multichain_chain_last_block_timestamp_seconds{chain} gauge, set inside processBlock for each chain using the block's own timestamp. Fixes Grafana panels computing time() - <gauge> showing ~56 years because the auto-registered indexer_last_block_timestamp_seconds was never written and stayed at 0.
