### PR TITLE
fix(indexer-multichain): guard chainLastBlockTimestamp.set against mi…

### DIFF
--- a/apps/indexer-multichain/src/services/bitcoin.ts
+++ b/apps/indexer-multichain/src/services/bitcoin.ts
@@ -96,7 +96,11 @@ const processBlock = async ({ chain, height, interval, url }: BlockProcess) => {
     throw new NotFoundError(`${chain}: block not found: ${height}`);
   }
 
-  chainLastBlockTimestamp.set({ chain }, block.timestamp);
+  // Guard against missing timestamp on malformed RPC responses; skip the
+  // gauge update rather than throwing inside the block processor.
+  if (typeof block.timestamp === 'number' && Number.isFinite(block.timestamp)) {
+    chainLastBlockTimestamp.set({ chain }, block.timestamp);
+  }
 
   if (!block.tx?.length) return;
 

--- a/apps/indexer-multichain/src/services/evm.ts
+++ b/apps/indexer-multichain/src/services/evm.ts
@@ -90,7 +90,12 @@ const processBlock = async ({ chain, height, interval, url }: BlockProcess) => {
     throw new NotFoundError(`${chain}: block not found: ${height}`);
   }
 
-  chainLastBlockTimestamp.set({ chain }, parseInt(block.timestamp, 16));
+  const blockTimestamp = parseInt(block.timestamp, 16);
+  // parseInt yields NaN if the upstream response omits the timestamp; skip
+  // the gauge update so the series is not poisoned with NaN.
+  if (Number.isFinite(blockTimestamp)) {
+    chainLastBlockTimestamp.set({ chain }, blockTimestamp);
+  }
 
   if (!block.transactions?.length) return;
 

--- a/apps/indexer-multichain/src/services/solana.ts
+++ b/apps/indexer-multichain/src/services/solana.ts
@@ -93,7 +93,11 @@ const processBlock = async ({ chain, height, interval, url }: BlockProcess) => {
     return;
   }
 
-  chainLastBlockTimestamp.set({ chain }, block.blockTime);
+  // Solana RPC returns null blockTime for blocks without a confirmed timestamp;
+  // skip the gauge update rather than reporting a misleading value.
+  if (typeof block.blockTime === 'number' && Number.isFinite(block.blockTime)) {
+    chainLastBlockTimestamp.set({ chain }, block.blockTime);
+  }
 
   if (!block.transactions?.length) return;
 


### PR DESCRIPTION
…ssing timestamps

The new per-chain last-block-timestamp gauge crashed the indexer on Solana when an RPC response carried a null blockTime (unconfirmed/unproduced blocks): prom-client's gauge.set rejects non-numbers with "Value is not a valid number: undefined" and the unhandled throw inside processBlock took the process down.

Skip the .set entirely when the value is not a finite number rather than defaulting to 0, which would emit a misleading Unix epoch timestamp and trip the Grafana sync-lag alert (~56-year lag). Apply the same guard to the EVM (parseInt -> NaN when timestamp missing) and Bitcoin paths so this regression cannot recur on any chain.
