### PR TITLE
fix(frontend): mobile UI polish and layout standardization

### DIFF
--- a/apps/frontend/src/app/[lang]/address/[address]/layout.tsx
+++ b/apps/frontend/src/app/[lang]/address/[address]/layout.tsx
@@ -62,14 +62,14 @@ const AddressLayout = async ({ children, params }: Props) => {
 
   return (
     <LocaleProvider dictionary={dictionary} locale={lang}>
-      <main className="flex flex-1 flex-col pt-6 pb-10">
+      <main className="flex flex-1 flex-col pt-4 pb-10">
         <div className="container mx-auto px-4">
           <PageHeading
             apiTag="accounts"
             title={
-              <span className="flex flex-wrap items-center gap-2">
+              <span className="flex min-w-0 flex-wrap items-center gap-2">
                 <span className="text-muted-foreground">{t('heading')}</span>
-                <span>{address}</span>
+                <span className="break-all">{address}</span>
                 <Copy text={address} />
                 <AccountQr address={address} />
               </span>

--- a/apps/frontend/src/app/[lang]/blocks/layout.tsx
+++ b/apps/frontend/src/app/[lang]/blocks/layout.tsx
@@ -14,7 +14,7 @@ const BlocksLayout = async ({ children, params }: Props) => {
 
   return (
     <LocaleProvider dictionary={dictionary} locale={lang}>
-      <main className="flex flex-1 flex-col pt-6 pb-10">
+      <main className="flex flex-1 flex-col pt-4 pb-10">
         <div className="container mx-auto px-4">{children}</div>
       </main>
     </LocaleProvider>

--- a/apps/frontend/src/app/[lang]/charts/layout.tsx
+++ b/apps/frontend/src/app/[lang]/charts/layout.tsx
@@ -14,7 +14,7 @@ const ChartsLayout = async ({ children, params }: Props) => {
 
   return (
     <LocaleProvider dictionary={dictionary} locale={lang}>
-      <main className="flex flex-1 flex-col pt-6 pb-10">
+      <main className="flex flex-1 flex-col pt-4 pb-10">
         <div className="container mx-auto px-4">{children}</div>
       </main>
     </LocaleProvider>

--- a/apps/frontend/src/app/[lang]/mt-tokens/layout.tsx
+++ b/apps/frontend/src/app/[lang]/mt-tokens/layout.tsx
@@ -14,7 +14,7 @@ const MtTokensLayout = async ({ children, params }: Props) => {
 
   return (
     <LocaleProvider dictionary={dictionary} locale={lang}>
-      <main className="flex flex-1 flex-col pt-6 pb-10">
+      <main className="flex flex-1 flex-col pt-4 pb-10">
         <div className="container mx-auto px-4">{children}</div>
       </main>
     </LocaleProvider>

--- a/apps/frontend/src/app/[lang]/multichain-txns/layout.tsx
+++ b/apps/frontend/src/app/[lang]/multichain-txns/layout.tsx
@@ -14,7 +14,7 @@ const MultichainTxnsLayout = async ({ children, params }: Props) => {
 
   return (
     <LocaleProvider dictionary={dictionary} locale={lang}>
-      <main className="flex flex-1 flex-col pt-6 pb-10">
+      <main className="flex flex-1 flex-col pt-4 pb-10">
         <div className="container mx-auto px-4">{children}</div>
       </main>
     </LocaleProvider>

--- a/apps/frontend/src/app/[lang]/near-intents/layout.tsx
+++ b/apps/frontend/src/app/[lang]/near-intents/layout.tsx
@@ -15,7 +15,7 @@ const NearIntentsLayout = async ({ children, params }: Props) => {
 
   return (
     <LocaleProvider dictionary={dictionary} locale={lang}>
-      <main className="flex flex-1 flex-col pt-6 pb-10">
+      <main className="flex flex-1 flex-col pt-4 pb-10">
         <div className="container mx-auto px-4">{children}</div>
       </main>
     </LocaleProvider>

--- a/apps/frontend/src/app/[lang]/nft-tokens/layout.tsx
+++ b/apps/frontend/src/app/[lang]/nft-tokens/layout.tsx
@@ -14,7 +14,7 @@ const NftTokensLayout = async ({ children, params }: Props) => {
 
   return (
     <LocaleProvider dictionary={dictionary} locale={lang}>
-      <main className="flex flex-1 flex-col pt-6 pb-10">
+      <main className="flex flex-1 flex-col pt-4 pb-10">
         <div className="container mx-auto px-4">{children}</div>
       </main>
     </LocaleProvider>

--- a/apps/frontend/src/app/[lang]/receipts/layout.tsx
+++ b/apps/frontend/src/app/[lang]/receipts/layout.tsx
@@ -14,7 +14,7 @@ const ReceiptsLayout = async ({ children, params }: Props) => {
 
   return (
     <LocaleProvider dictionary={dictionary} locale={lang}>
-      <main className="flex flex-1 flex-col pt-6 pb-10">
+      <main className="flex flex-1 flex-col pt-4 pb-10">
         <div className="container mx-auto px-4">{children}</div>
       </main>
     </LocaleProvider>

--- a/apps/frontend/src/app/[lang]/staking-txns/layout.tsx
+++ b/apps/frontend/src/app/[lang]/staking-txns/layout.tsx
@@ -14,7 +14,7 @@ const StakingTxnsLayout = async ({ children, params }: Props) => {
 
   return (
     <LocaleProvider dictionary={dictionary} locale={lang}>
-      <main className="flex flex-1 flex-col pt-6 pb-10">
+      <main className="flex flex-1 flex-col pt-4 pb-10">
         <div className="container mx-auto px-4">{children}</div>
       </main>
     </LocaleProvider>

--- a/apps/frontend/src/app/[lang]/tokens/layout.tsx
+++ b/apps/frontend/src/app/[lang]/tokens/layout.tsx
@@ -14,7 +14,7 @@ const TokensLayout = async ({ children, params }: Props) => {
 
   return (
     <LocaleProvider dictionary={dictionary} locale={lang}>
-      <main className="flex flex-1 flex-col pt-6 pb-10">
+      <main className="flex flex-1 flex-col pt-4 pb-10">
         <div className="container mx-auto px-4">{children}</div>
       </main>
     </LocaleProvider>

--- a/apps/frontend/src/app/[lang]/txns/layout.tsx
+++ b/apps/frontend/src/app/[lang]/txns/layout.tsx
@@ -14,7 +14,7 @@ const TxnsLayout = async ({ children, params }: Props) => {
 
   return (
     <LocaleProvider dictionary={dictionary} locale={lang}>
-      <main className="flex flex-1 flex-col pt-6 pb-10">
+      <main className="flex flex-1 flex-col pt-4 pb-10">
         <div className="container mx-auto px-4">{children}</div>
       </main>
     </LocaleProvider>

--- a/apps/frontend/src/app/[lang]/validators/layout.tsx
+++ b/apps/frontend/src/app/[lang]/validators/layout.tsx
@@ -14,7 +14,7 @@ const ValidatorsLayout = async ({ children, params }: Props) => {
 
   return (
     <LocaleProvider dictionary={dictionary} locale={lang}>
-      <main className="flex flex-1 flex-col pt-6 pb-10">
+      <main className="flex flex-1 flex-col pt-4 pb-10">
         <div className="container mx-auto px-4">{children}</div>
       </main>
     </LocaleProvider>

--- a/apps/frontend/src/components/address/analytics/heatmap.tsx
+++ b/apps/frontend/src/components/address/analytics/heatmap.tsx
@@ -212,9 +212,11 @@ export const Heatmap = memo(({ data, height = 184 }: Props) => {
 
   return (
     <div className="heatmap-chart">
-      <Chart options={options}>
-        <HeatmapSeries.Series data={points} />
-      </Chart>
+      <div className="overflow-x-auto">
+        <Chart options={options}>
+          <HeatmapSeries.Series data={points} />
+        </Chart>
+      </div>
       <div className="text-body-xs text-muted-foreground flex items-center justify-end gap-1">
         <div className="mr-2">{t('analytics.heatmap.less')}</div>
         {ranges.map((range, index) => (

--- a/apps/frontend/src/components/address/info.tsx
+++ b/apps/frontend/src/components/address/info.tsx
@@ -29,9 +29,9 @@ export const Info = ({ accountPromise, balancePromise, loading }: Props) => {
   return (
     <Card>
       <CardHeader className="border-b py-3">
-        <CardTitle className="text-headline-base">{t('info.title')}</CardTitle>
+        <CardTitle className="text-headline-sm">{t('info.title')}</CardTitle>
       </CardHeader>
-      <CardContent className="px-3">
+      <CardContent className="px-1">
         <List pairsPerRow={1}>
           <ListItem>
             <ListLeft className="min-w-30">{t('info.stakedBalance')}</ListLeft>

--- a/apps/frontend/src/components/address/overview.tsx
+++ b/apps/frontend/src/components/address/overview.tsx
@@ -42,11 +42,11 @@ export const Overview = ({
   return (
     <Card>
       <CardHeader className="border-b py-3">
-        <CardTitle className="text-headline-base">
+        <CardTitle className="text-headline-sm">
           {t('overview.title')}
         </CardTitle>
       </CardHeader>
-      <CardContent className="px-3">
+      <CardContent className="px-1">
         <List pairsPerRow={1}>
           <ListItem>
             <ListLeft className="min-w-20">{t('overview.balance')}</ListLeft>

--- a/apps/frontend/src/components/blocks/overview.tsx
+++ b/apps/frontend/src/components/blocks/overview.tsx
@@ -31,11 +31,14 @@ export const Overview = ({ blockPromise, loading }: Props) => {
 
   return (
     <Card>
-      <CardContent className="px-2 py-2">
+      <CardContent className="px-0 py-2">
         {network !== 'mainnet' && (
-          <p className="text-red-foreground text-body-2xs px-1 py-2">
-            [{t('overview.testnetNotice')}]
-          </p>
+          <>
+            <p className="text-red-foreground text-body-2xs px-3 py-2">
+              [{t('overview.testnetNotice')}]
+            </p>
+            <hr className="border-border" />
+          </>
         )}
         <List pairsPerRow={1}>
           <ListItem>
@@ -109,7 +112,7 @@ export const Overview = ({ blockPromise, loading }: Props) => {
               {t('overview.timestamp')}
             </ListLeft>
             <ListRight>
-              <p className="flex h-7 items-center">
+              <p className="flex items-center">
                 <SkeletonSlot
                   fallback={<Skeleton className="h-7 w-60" />}
                   loading={loading || !block}
@@ -192,7 +195,7 @@ export const Overview = ({ blockPromise, loading }: Props) => {
           </ListItem>
         </List>
 
-        <hr className="border-border my-2" />
+        <hr className="border-border" />
 
         <List pairsPerRow={1}>
           <ListItem>

--- a/apps/frontend/src/components/home/blocks.tsx
+++ b/apps/frontend/src/components/home/blocks.tsx
@@ -38,7 +38,7 @@ export const Blocks = ({ blocksPromise, loading }: Props) => {
       <CardHeader className="border-b py-3">
         <CardTitle className="text-headline-sm">{t('blocks.title')}</CardTitle>
       </CardHeader>
-      <ScrollArea className="h-78.5">
+      <ScrollArea className="h-110 lg:h-78.5">
         <CardContent className="@container p-3">
           <SkeletonSlot
             fallback={

--- a/apps/frontend/src/components/home/txns.tsx
+++ b/apps/frontend/src/components/home/txns.tsx
@@ -39,7 +39,7 @@ export const Txns = ({ loading, txnsPromise }: Props) => {
       <CardHeader className="border-b py-3">
         <CardTitle className="text-headline-sm">{t('txns.title')}</CardTitle>
       </CardHeader>
-      <ScrollArea className="h-78.5">
+      <ScrollArea className="h-110 lg:h-78.5">
         <CardContent className="@container p-3">
           <SkeletonSlot
             fallback={
@@ -69,13 +69,15 @@ export const Txns = ({ loading, txnsPromise }: Props) => {
                           <Skeleton className="w-10" />
                         </Badge>
                       </div>
-                      <div className="text-body-sm flex flex-col gap-1 @lg:flex-1">
-                        <h4 className="flex gap-1 font-normal">
-                          {t('txns.from')} <Skeleton className="w-40" />
+                      <div className="text-body-sm grid grid-cols-[auto_minmax(0,1fr)] items-center gap-x-1 gap-y-1 @lg:flex-1">
+                        <h4 className="font-normal whitespace-nowrap">
+                          {t('txns.from')}
                         </h4>
-                        <h4 className="flex gap-1 pt-0 font-normal">
-                          {t('txns.to')} <Skeleton className="w-40" />
+                        <Skeleton className="w-40" />
+                        <h4 className="font-normal whitespace-nowrap">
+                          {t('txns.to')}
                         </h4>
+                        <Skeleton className="w-40" />
                       </div>
                       <Badge
                         className="text-body-xs hidden h-6 @lg:ml-auto @lg:inline-flex"
@@ -129,25 +131,25 @@ export const Txns = ({ loading, txnsPromise }: Props) => {
                             {amount}
                           </Badge>
                         </div>
-                        <div className="text-body-sm flex flex-col gap-1 @lg:flex-1">
-                          <h4 className="flex gap-1 font-normal whitespace-nowrap">
-                            {t('txns.from')}{' '}
-                            <Link
-                              className="text-link inline-block w-40 truncate"
-                              href={`/address/${txn.signer_account_id}`}
-                            >
-                              {txn.signer_account_id}
-                            </Link>
+                        <div className="text-body-sm grid grid-cols-[auto_minmax(0,1fr)] items-center gap-x-1 gap-y-1 @lg:flex-1">
+                          <h4 className="font-normal whitespace-nowrap">
+                            {t('txns.from')}
                           </h4>
-                          <h4 className="flex gap-1 pt-0 font-normal whitespace-nowrap">
-                            {t('txns.to')}{' '}
-                            <Link
-                              className="text-link inline-block w-40 truncate"
-                              href={`/address/${txn.receiver_account_id}`}
-                            >
-                              {txn.receiver_account_id}
-                            </Link>
+                          <Link
+                            className="text-link inline-block w-40 truncate"
+                            href={`/address/${txn.signer_account_id}`}
+                          >
+                            {txn.signer_account_id}
+                          </Link>
+                          <h4 className="font-normal whitespace-nowrap">
+                            {t('txns.to')}
                           </h4>
+                          <Link
+                            className="text-link inline-block w-40 truncate"
+                            href={`/address/${txn.receiver_account_id}`}
+                          >
+                            {txn.receiver_account_id}
+                          </Link>
                         </div>
                         <Badge
                           className="text-body-xs hidden h-6 @lg:ml-auto @lg:inline-flex"

--- a/apps/frontend/src/components/layout/header.tsx
+++ b/apps/frontend/src/components/layout/header.tsx
@@ -22,8 +22,6 @@ import {
 
 import { Menu } from './menu';
 import { MobileMenu } from './mobile-menu';
-import { NetworkSwitcher } from './network';
-import { ThemeToggle } from './theme';
 
 const languageChoices: { locale: Locale; title: string }[] = [
   { locale: 'en', title: 'English' },
@@ -134,8 +132,6 @@ export const Header = () => {
             <div className="text-headline-sm ml-auto flex gap-2">
               <Menu menu={menu} />
               <div className="flex items-center gap-2 lg:hidden">
-                <NetworkSwitcher />
-                <ThemeToggle />
                 <PopoverTrigger asChild>
                   <Button
                     className="group relative"
@@ -155,14 +151,13 @@ export const Header = () => {
         <PopoverContent
           align="center"
           autoFocus={false}
-          className="w-(--radix-popper-available-width) rounded-t-none"
+          className="w-(--radix-popper-available-width) rounded-none border-x-0 px-0"
+          collisionPadding={0}
           onOpenAutoFocus={(event) => event.preventDefault()}
           side="bottom"
           sideOffset={0}
         >
-          <div className="container mx-auto px-4">
-            <MobileMenu menu={menu} />
-          </div>
+          <MobileMenu menu={menu} />
         </PopoverContent>
       </Popover>
     </header>

--- a/apps/frontend/src/components/layout/mobile-menu.tsx
+++ b/apps/frontend/src/components/layout/mobile-menu.tsx
@@ -1,12 +1,19 @@
 'use client';
 
-import { ChevronRight } from 'lucide-react';
+import { Check, ChevronRight, Moon, Sun } from 'lucide-react';
+import { useTransition } from 'react';
 
+import { setTheme } from '@/actions/theme';
+import { useConfig } from '@/hooks/use-config';
 import { useLocale } from '@/hooks/use-locale';
+import { useTheme } from '@/hooks/use-theme';
+import { cn } from '@/lib/utils';
+import { Theme } from '@/types/enums';
 import { isNavMenuDivider, NavMenu, RouteKey } from '@/types/types';
 import { Collapsible, CollapsibleContent } from '@/ui/collapsible';
 import {
   mobileNavigationCollapsibleTriggerStyle,
+  mobileNavigationLinkStyle,
   MobileNavigationMenu,
   MobileNavigationMenuCollapsibleTrigger,
   MobileNavigationMenuItem,
@@ -22,6 +29,15 @@ type Props = {
 
 export const MobileMenu = ({ menu }: Props) => {
   const { t } = useLocale('layout');
+  const theme = useTheme();
+  const [, startTransition] = useTransition();
+  const network = useConfig((c) => c.config.network);
+  const mainnetUrl = useConfig((c) => c.config.mainnetUrl);
+  const testnetUrl = useConfig((c) => c.config.testnetUrl);
+  const onTheme = (value: Theme) =>
+    startTransition(() => {
+      setTheme(value);
+    });
 
   return (
     <MobileNavigationMenu>
@@ -72,6 +88,85 @@ export const MobileMenu = ({ menu }: Props) => {
           </Collapsible>
         ),
       )}
+      <li>
+        <Separator orientation="horizontal" />
+      </li>
+      <Collapsible asChild>
+        <MobileNavigationMenuItem>
+          <MobileNavigationMenuCollapsibleTrigger>
+            <span>{t('header.switchNetwork')}</span>
+            <ChevronRight className="size-4 transition-transform duration-200 group-data-[state=open]:rotate-90" />
+          </MobileNavigationMenuCollapsibleTrigger>
+          <CollapsibleContent>
+            <ul className="border-border my-2 ml-4 border-l pl-2">
+              <MobileNavigationMenuItem>
+                <a
+                  className={cn(mobileNavigationLinkStyle(), 'justify-between')}
+                  href={mainnetUrl}
+                  rel="noopener noreferrer"
+                >
+                  Mainnet
+                  {network === 'mainnet' && <Check className="size-4" />}
+                </a>
+              </MobileNavigationMenuItem>
+              <MobileNavigationMenuItem>
+                <a
+                  className={cn(mobileNavigationLinkStyle(), 'justify-between')}
+                  href={testnetUrl}
+                  rel="noopener noreferrer"
+                >
+                  Testnet
+                  {network === 'testnet' && <Check className="size-4" />}
+                </a>
+              </MobileNavigationMenuItem>
+            </ul>
+          </CollapsibleContent>
+        </MobileNavigationMenuItem>
+      </Collapsible>
+      <Collapsible asChild>
+        <MobileNavigationMenuItem>
+          <MobileNavigationMenuCollapsibleTrigger>
+            <span>{t('header.toggleTheme')}</span>
+            <ChevronRight className="size-4 transition-transform duration-200 group-data-[state=open]:rotate-90" />
+          </MobileNavigationMenuCollapsibleTrigger>
+          <CollapsibleContent>
+            <ul className="border-border my-2 ml-4 border-l pl-2">
+              <MobileNavigationMenuItem>
+                <button
+                  className={cn(
+                    mobileNavigationLinkStyle(),
+                    'w-full justify-between',
+                  )}
+                  onClick={() => onTheme('light')}
+                  type="button"
+                >
+                  <span className="flex items-center gap-2">
+                    <Sun className="size-4" />
+                    Light
+                  </span>
+                  {theme === 'light' && <Check className="size-4" />}
+                </button>
+              </MobileNavigationMenuItem>
+              <MobileNavigationMenuItem>
+                <button
+                  className={cn(
+                    mobileNavigationLinkStyle(),
+                    'w-full justify-between',
+                  )}
+                  onClick={() => onTheme('dark')}
+                  type="button"
+                >
+                  <span className="flex items-center gap-2">
+                    <Moon className="size-4" />
+                    Dark
+                  </span>
+                  {theme === 'dark' && <Check className="size-4" />}
+                </button>
+              </MobileNavigationMenuItem>
+            </ul>
+          </CollapsibleContent>
+        </MobileNavigationMenuItem>
+      </Collapsible>
       <li>
         <Separator orientation="horizontal" />
       </li>

--- a/apps/frontend/src/components/link.tsx
+++ b/apps/frontend/src/components/link.tsx
@@ -205,14 +205,10 @@ export const AccountLink = ({
     <Link className={cn('text-link', className)} href={`/address/${account}`}>
       <Truncate>
         <TruncateText
-          className={cn(
-            textClassName,
-            'rounded-md border border-transparent px-1',
-            {
-              'bg-amber-background border-amber-foreground/20 border-dashed':
-                highlighted === account,
-            },
-          )}
+          className={cn(textClassName, '-ml-1 rounded-md px-1', {
+            'bg-amber-background outline-amber-foreground/20 outline-1 outline-dashed':
+              highlighted === account,
+          })}
           onMouseEnter={onEnter}
           onMouseLeave={onLeave}
           text={name ?? account}

--- a/apps/frontend/src/components/list.tsx
+++ b/apps/frontend/src/components/list.tsx
@@ -96,7 +96,7 @@ const ListLeft = ({ className, ...props }: ListLeftProps) => {
   return (
     <h3
       className={cn(
-        'text-muted-foreground border-b-0 px-3 py-3 md:py-3',
+        'text-muted-foreground border-b-0 px-3 pt-2 pb-0 md:py-3',
         'overflow-hidden md:flex md:items-center md:self-stretch group-data-[last-row=true]/list-item:md:border-b-0',
         className,
       )}
@@ -112,7 +112,7 @@ const ListRight = ({ className, ...props }: ListRightProps) => {
   return (
     <div
       className={cn(
-        'w-full min-w-0 border-b-0 px-3 py-3 md:py-3',
+        'w-full min-w-0 border-b-0 px-3 pt-0.5 pb-2 md:py-3',
         'overflow-hidden md:flex md:items-center md:self-stretch group-data-[last-row=true]/list-item:md:border-b-0',
         className,
       )}

--- a/apps/frontend/src/components/nft-tokens/token/overview.tsx
+++ b/apps/frontend/src/components/nft-tokens/token/overview.tsx
@@ -42,7 +42,7 @@ export const Overview = ({
           {t('contract.overview.title')}
         </CardTitle>
       </CardHeader>
-      <CardContent className="px-3">
+      <CardContent className="px-1">
         <List pairsPerRow={1}>
           <ListItem>
             <ListLeft className="min-w-36">

--- a/apps/frontend/src/components/nft-tokens/token/profile.tsx
+++ b/apps/frontend/src/components/nft-tokens/token/profile.tsx
@@ -29,7 +29,7 @@ export const Profile = ({ cid, contractPromise, loading }: Props) => {
           {t('contract.profile.title')}
         </CardTitle>
       </CardHeader>
-      <CardContent className="px-3">
+      <CardContent className="px-1">
         <List pairsPerRow={1}>
           <ListItem>
             <ListLeft className="min-w-28">

--- a/apps/frontend/src/components/nft-tokens/token/token/overview.tsx
+++ b/apps/frontend/src/components/nft-tokens/token/token/overview.tsx
@@ -55,7 +55,7 @@ export const NftOverview = ({
             {t('token.overview')}
           </CardTitle>
         </CardHeader>
-        <CardContent className="px-3">
+        <CardContent className="px-1">
           <List pairsPerRow={1}>
             <ListItem>
               <ListLeft className="min-w-40">{t('token.owner')}</ListLeft>

--- a/apps/frontend/src/components/page-heading.tsx
+++ b/apps/frontend/src/components/page-heading.tsx
@@ -25,7 +25,7 @@ export const ApiBadge = ({
   return (
     <a
       className={cn(
-        'border-border text-muted-foreground hover:text-primary hover:border-primary text-body-sm inline-flex h-8 cursor-pointer items-center gap-1 rounded-md border px-2.5 transition-colors',
+        'border-border text-muted-foreground hover:text-primary hover:border-primary text-body-sm inline-flex h-8 shrink-0 cursor-pointer items-center gap-1 rounded-md border px-2.5 whitespace-nowrap transition-colors',
         className,
       )}
       href={apiDocsUrl(network, tag)}
@@ -45,13 +45,18 @@ type Props = {
 };
 
 export const PageHeading = ({ apiTag, children, title }: Props) => (
-  <div className="border-border mb-6 flex items-center justify-between gap-3 border-b pb-3">
-    <div className="flex items-center gap-2">
-      <h1 className="text-body-lg">{title}</h1>
-      {apiTag !== undefined && (
-        <ApiBadge className="text-body-xs h-7 px-2" tag={apiTag} />
-      )}
-    </div>
-    {children}
+  <div className="border-border mb-3 flex flex-col gap-2 border-b pb-3 sm:flex-row sm:items-center sm:justify-between sm:gap-3">
+    <h1 className="text-body-lg min-w-0">{title}</h1>
+    {(apiTag !== undefined || children) && (
+      <div className="flex shrink-0 flex-wrap items-center gap-2">
+        {apiTag !== undefined && (
+          <ApiBadge
+            className="text-body-xs hidden h-7 px-2 sm:inline-flex"
+            tag={apiTag}
+          />
+        )}
+        {children}
+      </div>
+    )}
   </div>
 );

--- a/apps/frontend/src/components/stat-card.tsx
+++ b/apps/frontend/src/components/stat-card.tsx
@@ -36,7 +36,7 @@ const StatBody = ({
     {href && (
       <ArrowUpRight className="text-muted-foreground group-hover:text-primary absolute top-3 right-3 size-4 opacity-0 transition-opacity group-hover:opacity-100" />
     )}
-    <p className="text-body-lg text-foreground mt-1 flex h-7 items-center gap-1">
+    <p className="text-body-lg text-foreground mt-1 flex min-h-7 items-center gap-1">
       <SkeletonSlot
         fallback={
           <>

--- a/apps/frontend/src/components/timestamp.tsx
+++ b/apps/frontend/src/components/timestamp.tsx
@@ -78,17 +78,21 @@ export const LongDate = ({ hideAge = false, ns }: LongDateProps) => {
   if (!ns || !hasHydrated) return <Skeleton className="w-60" />;
 
   const ms = toMs(ns);
-  const date = dateFormat(ms, 'MMM D, YYYY HH:mm:ss.SSS Z', utcMode === 'utc');
+  const date = dateFormat(ms, 'MMM D, YYYY HH:mm:ss Z', utcMode === 'utc');
 
   return (
-    <span className="inline-flex items-center gap-2">
+    <span>
       <span>
         {!hideAge && `${ageFormat(ms)} `}
         {hideAge ? date : `(${date})`}
       </span>
       <DropdownMenu>
         <DropdownMenuTrigger asChild>
-          <Button size="xs" variant="outline">
+          <Button
+            className="ml-1 inline-flex align-middle"
+            size="xs"
+            variant="outline"
+          >
             {utcMode === 'local' ? 'Local' : 'UTC'}
             <ChevronDown className="ml-0.5 size-3" />
           </Button>

--- a/apps/frontend/src/components/tokens/token/info.tsx
+++ b/apps/frontend/src/components/tokens/token/info.tsx
@@ -52,7 +52,7 @@ export const TokenInfo = ({ contractPromise, loading }: Props) => {
             {t('info.marketTitle')}
           </CardTitle>
         </CardHeader>
-        <CardContent className="px-3">
+        <CardContent className="px-1">
           <List pairsPerRow={2}>
             <ListItem>
               <ListLeft className="min-w-36">{t('info.marketCap')}</ListLeft>

--- a/apps/frontend/src/components/tokens/token/overview.tsx
+++ b/apps/frontend/src/components/tokens/token/overview.tsx
@@ -44,7 +44,7 @@ export const Overview = ({
           {t('overview.title')}
         </CardTitle>
       </CardHeader>
-      <CardContent className="px-3">
+      <CardContent className="px-1">
         <List pairsPerRow={2}>
           <ListItem>
             <div>

--- a/apps/frontend/src/components/tokens/token/profile.tsx
+++ b/apps/frontend/src/components/tokens/token/profile.tsx
@@ -44,7 +44,7 @@ export const Profile = ({ cid, contractPromise, loading }: Props) => {
       <CardHeader className="border-b py-3">
         <CardTitle className="text-headline-sm">{t('profile.title')}</CardTitle>
       </CardHeader>
-      <CardContent className="px-3">
+      <CardContent className="px-1">
         <List pairsPerRow={1}>
           <ListItem>
             <ListLeft className="min-w-28">{t('profile.contract')}</ListLeft>

--- a/apps/frontend/src/components/txns/txn/actions/action.tsx
+++ b/apps/frontend/src/components/txns/txn/actions/action.tsx
@@ -15,6 +15,7 @@ import { Badge } from '@/ui/badge';
 type Props = {
   action: ActionReceipt;
   full?: boolean;
+  hideCopy?: boolean;
   receiver: string;
   signer: string;
 };
@@ -24,7 +25,13 @@ export const argsRecord = (args: JsonData): Record<string, JsonData> =>
     ? (args as Record<string, JsonData>)
     : {};
 
-export const Action = ({ action, full = true, receiver, signer }: Props) => {
+export const Action = ({
+  action,
+  full = true,
+  hideCopy = false,
+  receiver,
+  signer,
+}: Props) => {
   const { t } = useLocale('txns');
   const args = argsRecord(action.args);
 
@@ -38,9 +45,17 @@ export const Action = ({ action, full = true, receiver, signer }: Props) => {
               <code>{action.method || 'method'}</code>
             </Badge>{' '}
             {t('actions.by')}{' '}
-            <AccountLink account={signer} textClassName="max-w-40" />{' '}
+            <AccountLink
+              account={signer}
+              hideCopy={hideCopy}
+              textClassName="max-w-32 sm:max-w-40"
+            />{' '}
             {t('actions.on')}{' '}
-            <AccountLink account={receiver} textClassName="max-w-40" />
+            <AccountLink
+              account={receiver}
+              hideCopy={hideCopy}
+              textClassName="max-w-32 sm:max-w-40"
+            />
           </>
         ) : (
           <>
@@ -49,7 +64,11 @@ export const Action = ({ action, full = true, receiver, signer }: Props) => {
               <code>{action.method || 'method'}</code>
             </Badge>{' '}
             {t('actions.inContract')}{' '}
-            <AccountLink account={receiver} textClassName="max-w-40" />
+            <AccountLink
+              account={receiver}
+              hideCopy={hideCopy}
+              textClassName="max-w-32 sm:max-w-40"
+            />
           </>
         )}
       </span>
@@ -65,9 +84,17 @@ export const Action = ({ action, full = true, receiver, signer }: Props) => {
           <>
             {' '}
             {t('actions.from')}{' '}
-            <AccountLink account={signer} textClassName="max-w-40" />{' '}
+            <AccountLink
+              account={signer}
+              hideCopy={hideCopy}
+              textClassName="max-w-32 sm:max-w-40"
+            />{' '}
             {t('actions.to')}{' '}
-            <AccountLink account={receiver} textClassName="max-w-40" />
+            <AccountLink
+              account={receiver}
+              hideCopy={hideCopy}
+              textClassName="max-w-32 sm:max-w-40"
+            />
           </>
         )}
       </span>
@@ -83,9 +110,17 @@ export const Action = ({ action, full = true, receiver, signer }: Props) => {
           <>
             {' '}
             {t('actions.to')}{' '}
-            <AccountLink account={receiver} textClassName="max-w-40" />{' '}
+            <AccountLink
+              account={receiver}
+              hideCopy={hideCopy}
+              textClassName="max-w-32 sm:max-w-40"
+            />{' '}
             {t('actions.by')}{' '}
-            <AccountLink account={signer} textClassName="max-w-40" />
+            <AccountLink
+              account={signer}
+              hideCopy={hideCopy}
+              textClassName="max-w-32 sm:max-w-40"
+            />
           </>
         )}
       </span>
@@ -100,7 +135,11 @@ export const Action = ({ action, full = true, receiver, signer }: Props) => {
           <>
             {' '}
             {t('actions.to')}{' '}
-            <AccountLink account={receiver} textClassName="max-w-40" />
+            <AccountLink
+              account={receiver}
+              hideCopy={hideCopy}
+              textClassName="max-w-32 sm:max-w-40"
+            />
           </>
         )}
       </span>
@@ -120,7 +159,11 @@ export const Action = ({ action, full = true, receiver, signer }: Props) => {
           <>
             {' '}
             {t('actions.to')}{' '}
-            <AccountLink account={receiver} textClassName="max-w-40" />
+            <AccountLink
+              account={receiver}
+              hideCopy={hideCopy}
+              textClassName="max-w-32 sm:max-w-40"
+            />
           </>
         )}
       </span>
@@ -134,7 +177,11 @@ export const Action = ({ action, full = true, receiver, signer }: Props) => {
         {full && (
           <>
             {' '}
-            <AccountLink account={receiver} textClassName="max-w-40" />
+            <AccountLink
+              account={receiver}
+              hideCopy={hideCopy}
+              textClassName="max-w-32 sm:max-w-40"
+            />
           </>
         )}
       </span>
@@ -148,7 +195,11 @@ export const Action = ({ action, full = true, receiver, signer }: Props) => {
         {full && (
           <>
             {' '}
-            <AccountLink account={receiver} textClassName="max-w-40" />
+            <AccountLink
+              account={receiver}
+              hideCopy={hideCopy}
+              textClassName="max-w-32 sm:max-w-40"
+            />
           </>
         )}
       </span>
@@ -162,7 +213,11 @@ export const Action = ({ action, full = true, receiver, signer }: Props) => {
         {full && (
           <>
             {' '}
-            <AccountLink account={receiver} textClassName="max-w-40" />
+            <AccountLink
+              account={receiver}
+              hideCopy={hideCopy}
+              textClassName="max-w-32 sm:max-w-40"
+            />
           </>
         )}
       </span>
@@ -177,7 +232,11 @@ export const Action = ({ action, full = true, receiver, signer }: Props) => {
           <>
             {' '}
             {t('actions.for')}{' '}
-            <AccountLink account={receiver} textClassName="max-w-40" />
+            <AccountLink
+              account={receiver}
+              hideCopy={hideCopy}
+              textClassName="max-w-32 sm:max-w-40"
+            />
           </>
         )}
       </span>
@@ -189,7 +248,7 @@ export const Action = ({ action, full = true, receiver, signer }: Props) => {
       <span className="text-body-sm flex flex-wrap items-center gap-1">
         {t('actions.addKey')}{' '}
         <Link
-          className="text-link max-w-40 truncate"
+          className="text-link max-w-32 truncate sm:max-w-40"
           href={`/address/${receiver}/keys`}
         >
           {String(args.public_key ?? '')}
@@ -202,7 +261,11 @@ export const Action = ({ action, full = true, receiver, signer }: Props) => {
           <>
             {' '}
             {t('actions.for')}{' '}
-            <AccountLink account={receiver} textClassName="max-w-40" />
+            <AccountLink
+              account={receiver}
+              hideCopy={hideCopy}
+              textClassName="max-w-32 sm:max-w-40"
+            />
           </>
         )}
       </span>
@@ -214,7 +277,7 @@ export const Action = ({ action, full = true, receiver, signer }: Props) => {
       <span className="text-body-sm flex flex-wrap items-center gap-1">
         {t('actions.deleteKey')}{' '}
         <Link
-          className="text-link max-w-40 truncate"
+          className="text-link max-w-32 truncate sm:max-w-40"
           href={`/address/${receiver}/keys`}
         >
           {String(args.public_key ?? '')}
@@ -227,7 +290,11 @@ export const Action = ({ action, full = true, receiver, signer }: Props) => {
           <>
             {' '}
             {t('actions.from')}{' '}
-            <AccountLink account={receiver} textClassName="max-w-40" />
+            <AccountLink
+              account={receiver}
+              hideCopy={hideCopy}
+              textClassName="max-w-32 sm:max-w-40"
+            />
           </>
         )}
       </span>

--- a/apps/frontend/src/components/txns/txn/actions/icon.tsx
+++ b/apps/frontend/src/components/txns/txn/actions/icon.tsx
@@ -22,6 +22,7 @@ import { Badge } from '@/ui/badge';
 
 type Props = {
   actions: null | Txn['actions'];
+  size?: 'default' | 'sm';
 };
 
 type IconProps = {
@@ -55,13 +56,17 @@ const variants = (action: ActionKind) => {
   }
 };
 
-const badgeClass = 'rounded-full size-10 p-0';
+export const TxnIcon = ({ actions, size = 'default' }: Props) => {
+  const badgeClass = cn(
+    'rounded-full p-0',
+    size === 'sm' ? 'size-6' : 'size-10',
+  );
+  const iconClass = size === 'sm' ? 'size-3!' : 'size-4!';
 
-export const TxnIcon = ({ actions }: Props) => {
   if (!actions || actions?.length === 0) {
     return (
       <Badge className={badgeClass} variant="gray">
-        <ActionIcon action={ActionKind.UNKNOWN} className="size-4!" />
+        <ActionIcon action={ActionKind.UNKNOWN} className={iconClass} />
       </Badge>
     );
   }
@@ -71,7 +76,7 @@ export const TxnIcon = ({ actions }: Props) => {
   if (actions?.length === 1) {
     return (
       <Badge className={cn(badgeClass, variant.bg, variant.color)}>
-        <ActionIcon action={actions[0].action} className="size-4!" />
+        <ActionIcon action={actions[0].action} className={iconClass} />
       </Badge>
     );
   }
@@ -79,14 +84,14 @@ export const TxnIcon = ({ actions }: Props) => {
   if (actions?.[0].action === ActionKind.DELEGATE_ACTION) {
     return (
       <Badge className={cn(badgeClass, variant.bg, variant.color)}>
-        <ActionIcon action={ActionKind.DELEGATE_ACTION} className="size-4!" />
+        <ActionIcon action={ActionKind.DELEGATE_ACTION} className={iconClass} />
       </Badge>
     );
   }
 
   return (
     <Badge className={badgeClass} variant="purple">
-      <Layers className="size-4!" />
+      <Layers className={iconClass} />
     </Badge>
   );
 };

--- a/apps/frontend/src/components/txns/txn/actions/index.tsx
+++ b/apps/frontend/src/components/txns/txn/actions/index.tsx
@@ -25,9 +25,9 @@ export const Actions = ({ loading, txnPromise }: Props) => {
 
   return (
     <Card>
-      <CardContent className="px-3 py-3">
+      <CardContent className="px-3 py-2.5">
         <div className="flex items-center gap-3">
-          <div className="shrink-0">
+          <div className="hidden shrink-0 sm:block">
             <SkeletonSlot
               fallback={<Skeleton className="size-10 rounded-full" />}
               loading={loading || !txn}
@@ -36,11 +36,21 @@ export const Actions = ({ loading, txnPromise }: Props) => {
             </SkeletonSlot>
           </div>
           <div className="min-w-0 flex-1">
-            <h2 className="text-headline-xs leading-normal font-medium uppercase">
-              {t('actions.title')}
-            </h2>
+            <div className="flex items-center gap-2">
+              <div className="shrink-0 sm:hidden">
+                <SkeletonSlot
+                  fallback={<Skeleton className="size-6 rounded-full" />}
+                  loading={loading || !txn}
+                >
+                  {() => <TxnIcon actions={txn!.actions} size="sm" />}
+                </SkeletonSlot>
+              </div>
+              <h2 className="text-headline-xs leading-normal font-medium uppercase">
+                {t('actions.title')}
+              </h2>
+            </div>
             <SkeletonSlot
-              fallback={<Skeleton className="mt-0.5 h-5 w-1/4" />}
+              fallback={<Skeleton className="mt-1.5 h-5 w-1/2" />}
               loading={loading || !txn || txn.actions?.length === 0}
             >
               {() => {
@@ -53,6 +63,7 @@ export const Actions = ({ loading, txnPromise }: Props) => {
                     {actions.map((action, index) => (
                       <Action
                         action={action}
+                        hideCopy
                         key={index}
                         receiver={txn!.receiver_account_id}
                         signer={txn!.signer_account_id}
@@ -60,12 +71,16 @@ export const Actions = ({ loading, txnPromise }: Props) => {
                     ))}
                   </div>
                 );
-                return actions.length > 3 ? (
-                  <ScrollableList className="max-h-40">
-                    {content}
-                  </ScrollableList>
-                ) : (
-                  content
+                return (
+                  <div className="mt-1">
+                    {actions.length > 3 ? (
+                      <ScrollableList className="max-h-40">
+                        {content}
+                      </ScrollableList>
+                    ) : (
+                      content
+                    )}
+                  </div>
                 );
               }}
             </SkeletonSlot>

--- a/apps/frontend/src/components/txns/txn/index.tsx
+++ b/apps/frontend/src/components/txns/txn/index.tsx
@@ -71,11 +71,14 @@ export const Overview = ({
 
   return (
     <Card>
-      <CardContent className="px-2 py-2">
+      <CardContent className="px-0 py-2">
         {network !== 'mainnet' && (
-          <p className="text-red-foreground text-body-2xs px-1 py-2">
-            [{t('overview.testnetNotice')}]
-          </p>
+          <>
+            <p className="text-red-foreground text-body-2xs px-3 py-2">
+              [{t('overview.testnetNotice')}]
+            </p>
+            <hr className="border-border" />
+          </>
         )}
         <List pairsPerRow={1}>
           <ListItem>
@@ -89,7 +92,7 @@ export const Overview = ({
               {t('overview.txnHash')}
             </ListLeft>
             <ListRight>
-              <p className="flex min-w-30 items-center gap-1">
+              <p className="min-w-30 break-all">
                 <SkeletonSlot
                   fallback={<Skeleton className="h-7 w-60" />}
                   loading={loading || !txn}
@@ -98,7 +101,7 @@ export const Overview = ({
                     <>
                       {txn!.transaction_hash}{' '}
                       <Copy
-                        className="text-muted-foreground"
+                        className="text-muted-foreground inline-flex align-middle"
                         size="icon-xs"
                         text={txn!.transaction_hash || ''}
                       />
@@ -178,7 +181,7 @@ export const Overview = ({
               {t('overview.timestamp')}
             </ListLeft>
             <ListRight>
-              <p className="flex h-7 items-center">
+              <p className="flex items-center">
                 <SkeletonSlot
                   fallback={<Skeleton className="h-7 w-60" />}
                   loading={loading || !txn}
@@ -211,7 +214,7 @@ export const Overview = ({
           </ListItem>
         </List>
 
-        <hr className="border-border my-2" />
+        <hr className="border-border" />
 
         <List pairsPerRow={1}>
           <ListItem>
@@ -275,7 +278,7 @@ export const Overview = ({
           />
         </List>
 
-        <hr className="border-border my-2" />
+        <hr className="border-border" />
 
         <List pairsPerRow={1}>
           <ListItem>

--- a/apps/frontend/src/components/validators/details.tsx
+++ b/apps/frontend/src/components/validators/details.tsx
@@ -210,7 +210,7 @@ export const NodeDetails = ({ node }: Props) => {
               {t('nodeDetails.overview')}
             </CardTitle>
           </CardHeader>
-          <CardContent className="px-3">
+          <CardContent className="px-1">
             <List pairsPerRow={1}>
               <ListItem>
                 <ListLeft className="min-w-20">
@@ -244,7 +244,7 @@ export const NodeDetails = ({ node }: Props) => {
               {t('nodeDetails.uptimeInfo')}
             </CardTitle>
           </CardHeader>
-          <CardContent className="px-3">
+          <CardContent className="px-1">
             <List pairsPerRow={1}>
               <ListItem>
                 <ListLeft className="min-w-20">

--- a/apps/frontend/src/components/validators/epoch.tsx
+++ b/apps/frontend/src/components/validators/epoch.tsx
@@ -56,7 +56,7 @@ export const EpochInfo = ({ loading, validators }: Props) => {
           {t('epochInfo.title')}
         </CardTitle>
       </CardHeader>
-      <CardContent className="px-3">
+      <CardContent className="px-1">
         <List pairsPerRow={1}>
           <ListItem>
             <ListLeft>{t('epochInfo.epochElapsed')}</ListLeft>

--- a/apps/frontend/src/components/validators/staking.tsx
+++ b/apps/frontend/src/components/validators/staking.tsx
@@ -26,7 +26,7 @@ export const StakingOverview = ({
       <CardHeader className="border-b py-3">
         <CardTitle className="text-headline-sm">{t('staking.title')}</CardTitle>
       </CardHeader>
-      <CardContent className="px-3">
+      <CardContent className="px-1">
         <List pairsPerRow={1}>
           <ListItem>
             <ListLeft>{t('staking.currentValidators')}</ListLeft>

--- a/apps/frontend/src/components/validators/validator.tsx
+++ b/apps/frontend/src/components/validators/validator.tsx
@@ -30,7 +30,7 @@ export const ValidatorInfo = ({ loading }: Props) => {
           {t('validatorInfo.title')}
         </CardTitle>
       </CardHeader>
-      <CardContent className="px-3">
+      <CardContent className="px-1">
         <List pairsPerRow={1}>
           <ListItem>
             <ListLeft>{t('validatorInfo.protocolVersion')}</ListLeft>

--- a/apps/frontend/src/locales/en/txns.ts
+++ b/apps/frontend/src/locales/en/txns.ts
@@ -1,7 +1,7 @@
 export const txns = {
   actions: {
     addKey: 'New Key',
-    by: 'By',
+    by: 'by',
     call: 'Call',
     calledMethod: 'Called method',
     createAccount: 'Create Account',
@@ -11,10 +11,10 @@ export const txns = {
     deleteKey: 'Delete Key',
     deployContract: 'Deploy Contract',
     deployGlobalContract: 'Deploy Global Contract',
-    for: 'For',
-    from: 'From',
+    for: 'for',
+    from: 'from',
     inContract: 'in contract',
-    on: 'On',
+    on: 'on',
     stake: 'Stake',
     title: 'Transaction Actions',
     to: 'To',

--- a/apps/frontend/src/ui/dropdown-menu.tsx
+++ b/apps/frontend/src/ui/dropdown-menu.tsx
@@ -39,6 +39,7 @@ const DropdownMenuContent = ({
   return (
     <DropdownMenuPrimitive.Portal>
       <DropdownMenuPrimitive.Content
+        collisionPadding={8}
         className={cn(
           'bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 max-h-(--radix-dropdown-menu-content-available-height) min-w-32 origin-(--radix-dropdown-menu-content-transform-origin) overflow-x-hidden overflow-y-auto rounded-md border p-1 shadow-md',
           className,

--- a/apps/frontend/src/ui/mobile-navigation-menu.tsx
+++ b/apps/frontend/src/ui/mobile-navigation-menu.tsx
@@ -24,7 +24,7 @@ const MobileNavigationMenu = ({
 }: MobileNavigationMenuProps) => {
   return (
     <nav>
-      <ul className={cn('space-y-2', className)} {...props} />
+      <ul className={cn('space-y-0.5', className)} {...props} />
     </nav>
   );
 };

--- a/apps/frontend/src/ui/popover.tsx
+++ b/apps/frontend/src/ui/popover.tsx
@@ -27,6 +27,7 @@ const PopoverContent = ({
     <PopoverPrimitive.Portal>
       <PopoverPrimitive.Content
         align={align}
+        collisionPadding={8}
         className={cn(
           'bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 w-72 origin-(--radix-popover-content-transform-origin) rounded-lg border p-4 shadow-md outline-hidden',
           className,


### PR DESCRIPTION
Spacing, alignment, and responsive fixes across the redesigned explorer, focused on mobile.

- List/overview rows: uniform spacing; values align with labels/icons
- AccountLink: negative margin offsets the hover-highlight padding so account text sits flush everywhere; outline-based highlight (no layout shift)
- LongDate: inline UTC toggle, drop milliseconds
- PageHeading: stack on mobile, hide API badge on mobile, tighter margins
- Dropdown/Popover: keep within viewport (collisionPadding)
- Txn/block overview: flush content, testnet-notice divider, uniform section dividers, inline hash copy
- Actions card: responsive icon (small on mobile), no inline copy buttons, lowercase connectors, method names wrapped in <code>
- Token/NFT/validator cards: align content with the card title
- Header: move theme + network into a full-width mobile dropdown
- Home: latest blocks/txns show 4 rows on mobile; aligned From/To columns
- Analytics heatmap scrolls horizontally on mobile
- Scale inline/prism code; pad testnet label; branch count copy approx vs exact
- Page layouts: reduce heading top padding (pt-6 -> pt-4)