### PR TITLE
fix(frontend): remove duplicate collisionPadding attribute

### DIFF
--- a/apps/frontend/src/ui/dropdown-menu.tsx
+++ b/apps/frontend/src/ui/dropdown-menu.tsx
@@ -39,7 +39,6 @@ const DropdownMenuContent = ({
   return (
     <DropdownMenuPrimitive.Portal>
       <DropdownMenuPrimitive.Content
-        collisionPadding={8}
         className={cn(
           'bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 max-h-(--radix-dropdown-menu-content-available-height) min-w-32 origin-(--radix-dropdown-menu-content-transform-origin) overflow-x-hidden overflow-y-auto rounded-md border p-1 shadow-md',
           className,

--- a/apps/frontend/src/ui/popover.tsx
+++ b/apps/frontend/src/ui/popover.tsx
@@ -27,7 +27,6 @@ const PopoverContent = ({
     <PopoverPrimitive.Portal>
       <PopoverPrimitive.Content
         align={align}
-        collisionPadding={8}
         className={cn(
           'bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 w-72 origin-(--radix-popover-content-transform-origin) rounded-lg border p-4 shadow-md outline-hidden',
           className,


### PR DESCRIPTION
Both DropdownMenuContent and PopoverContent had `collisionPadding={8}` declared twice on the same element, which fails the production type check (JSX elements cannot have multiple attributes with the same name) and broke `turbo build`. Drop the duplicate, out-of-order copy.
