### PR TITLE
feat(frontend): add API changes and make API doc links network-aware

### DIFF
--- a/apps/api/src/libs/apiDocumentation.ts
+++ b/apps/api/src/libs/apiDocumentation.ts
@@ -68,6 +68,15 @@ const apiDocumentation = async (app: Application, dir: string) => {
           <p><strong>⚠️ Deprecation notice:</strong> The v1 and v2 API endpoints are deprecated and will be removed in a future release. New integrations should use the current v3 API documented below. Documentation for the deprecated endpoints remains available at <a href="/api-docs/legacy">/api-docs/legacy</a>.</p>
         </div>
         <p>NearBlocks provides REST APIs for accessing NEAR Protocol blockchain data. Our APIs enable developers to retrieve account information, analyze smart contracts, and track transactions. You can access the REST APIs using cURL or any HTTP client. We support GET requests only.</p>
+        <h2>Migrating from v1/v2</h2>
+        <p>v3 is not a drop-in replacement for v1/v2. The main differences to plan for:</p>
+        <ul>
+        <li><strong>Numbers are strings.</strong> Token amounts, balances, deposits, gas and supply are returned as plain decimal strings (for example <code>"1234500000000000000000000000"</code>), never JSON numbers. Parse them with a big-number/decimal library &mdash; <code>Number()</code> or <code>parseInt()</code> will silently lose precision. (Some v1 aggregate amounts were returned as numbers and could appear in scientific notation such as <code>1e+24</code>; v3 never does.)</li>
+        <li><strong>Response envelope.</strong> Every response is wrapped as <code>{ "data": ..., "meta": ... }</code>, with any errors under <code>errors</code>, instead of a resource-named key.</li>
+        <li><strong>Cursor pagination.</strong> v3 uses opaque <code>next</code>/<code>prev</code> cursors together with <code>limit</code> (max 100). There is no <code>page</code>/<code>per_page</code>/<code>offset</code>; totals are exposed via separate <code>/count</code> endpoints.</li>
+        <li><strong>Nested structure.</strong> Related fields are grouped into objects such as <code>actions_agg</code> and <code>outcomes_agg</code> plus a nested <code>block</code>, and transaction receipts are returned as a nested tree.</li>
+        </ul>
+        <p>Documentation for the deprecated endpoints remains at <a href="/api-docs/legacy">/api-docs/legacy</a>.</p>
         <h2>Attribution Requirements</h2>
         <p>The APIs are offered as a community service and are provided without any warranty. Please use them responsibly and only for what you need.</p>
         <p>Attribution is required on the free plan only. You can attribute by either including a link back to Nearblocks.io or stating that your app is &quot;Powered by Nearblocks.io APIs.&quot; Paid plans do not require attribution.</p>

--- a/apps/api/src/libs/apiDocumentation.ts
+++ b/apps/api/src/libs/apiDocumentation.ts
@@ -21,6 +21,16 @@ const scalarCss = `
     padding-top: 60px;
     margin-top: 12px;
   }
+  .deprecation-callout {
+    border: 1px solid #f59e0b;
+    border-radius: 8px;
+    padding: 12px 16px;
+    margin: 0 0 20px;
+  }
+  .deprecation-callout p { margin: 0; }
+  .deprecation-callout a { color: inherit; text-decoration: underline; }
+  .light-mode .deprecation-callout { background: #fffbeb; color: #92400e; }
+  .dark-mode .deprecation-callout { background: rgba(245, 158, 11, 0.12); color: #fbbf24; }
 `;
 
 const scalarMeta = {
@@ -54,15 +64,14 @@ const apiDocumentation = async (app: Application, dir: string) => {
         },
       },
       info: {
-        description: `<p>NearBlocks provides REST APIs for accessing NEAR Protocol blockchain data. Our APIs enable developers to retrieve account information, analyze smart contracts, and track transactions. You can access the REST APIs using cURL or any HTTP client. We support GET requests only.</p>
-        <p><h2>Attribution Requirements:</h2></p>
+        description: `<div class="deprecation-callout">
+          <p><strong>⚠️ Deprecation notice:</strong> The v1 and v2 API endpoints are deprecated and will be removed in a future release. New integrations should use the current v3 API documented below. Documentation for the deprecated endpoints remains available at <a href="/api-docs/legacy">/api-docs/legacy</a>.</p>
+        </div>
+        <p>NearBlocks provides REST APIs for accessing NEAR Protocol blockchain data. Our APIs enable developers to retrieve account information, analyze smart contracts, and track transactions. You can access the REST APIs using cURL or any HTTP client. We support GET requests only.</p>
+        <h2>Attribution Requirements</h2>
         <p>The APIs are offered as a community service and are provided without any warranty. Please use them responsibly and only for what you need.</p>
-        <p>For any usage other than personal or private, attribution is required. This can be done by either:</p>
-        <ul>
-        <li>Including a link back to Nearblocks.io, or</li>
-        <li>Mentioning that your app is &quot;Powered by Nearblocks.io APIs.&quot;</li>
-        </ul>
-        <p>NearBlocks provides subscription-based API plans that provide higher rate limits for power users and commercial solutions. To upgrade to a paid API Plan, head over to the <a href="https://nearblocks.io/apis">APIs</a> page and select a plan that suits your needs. Once payment has been made, you can create API keys to make requests to our endpoints.</p>
+        <p>Attribution is required on the free plan only. You can attribute by either including a link back to Nearblocks.io or stating that your app is &quot;Powered by Nearblocks.io APIs.&quot; Paid plans do not require attribution.</p>
+        <p>To upgrade to a paid API plan with higher rate limits, head over to the <a href="https://nearblocks.io/apis">APIs</a> page and select a plan that suits your needs. Once payment has been made, you can create API keys to make requests to our endpoints.</p>
         <h2>Resources</h2>
         <ul>
           <li><a href="https://nearblocks.io/">Near Protocol Explorer</a></li>
@@ -82,8 +91,6 @@ const apiDocumentation = async (app: Application, dir: string) => {
             ? config.mainnetUrl
             : config.testnetUrl
         }/v3/accounts/wrap.near"</pre></code></p>
-        <h2>Legacy API</h2>
-        <p>Documentation for deprecated v1/v2 endpoints is available at <a href="/api-docs/legacy">/api-docs/legacy</a>. These endpoints will be removed in a future release.</p>
         `,
         title: ' ',
         version: '1.0.0',
@@ -184,8 +191,9 @@ const apiDocumentation = async (app: Application, dir: string) => {
         },
       },
       info: {
-        description: `<p><strong>These are deprecated endpoints. They will be removed in a future release.</strong></p>
-        <p>For new integrations, use the <a href="/api-docs">current API</a>.</p>
+        description: `<div class="deprecation-callout">
+          <p><strong>⚠️ Deprecated:</strong> These v1/v2 endpoints are deprecated and will be removed in a future release. For new integrations, use the <a href="/api-docs">current v3 API</a>.</p>
+        </div>
         `,
         title: ' ',
         version: '1.0.0',

--- a/apps/frontend/src/components/apis/index.tsx
+++ b/apps/frontend/src/components/apis/index.tsx
@@ -6,7 +6,9 @@ import Link from 'next/link';
 import { use, useState } from 'react';
 
 import type { ApiPlan } from '@/data/plans';
+import { useConfig } from '@/hooks/use-config';
 import { useLocale } from '@/hooks/use-locale';
+import { apiDocsUrl } from '@/lib/api-docs';
 import { numberFormat } from '@/lib/format';
 import { Button } from '@/ui/button';
 import { Card } from '@/ui/card';
@@ -35,6 +37,8 @@ type Props = {
 
 export const Apis = ({ plansPromise }: Props) => {
   const { t } = useLocale('apis');
+  const network = useConfig((s) => s.config.network);
+  const docsUrl = apiDocsUrl(network);
   const [isAnnual, setIsAnnual] = useState(true);
   const plans = use(plansPromise);
 
@@ -64,11 +68,7 @@ export const Apis = ({ plansPromise }: Props) => {
                 </a>
               </Button>
               <Button asChild size="lg" variant="ghost">
-                <a
-                  href="https://api.nearblocks.io/api-docs"
-                  rel="noopener noreferrer"
-                  target="_blank"
-                >
+                <a href={docsUrl} rel="noopener noreferrer" target="_blank">
                   {t('docs')}
                   <ArrowUpRight className="mt-2 -ml-1 size-3 self-start" />
                 </a>
@@ -272,11 +272,7 @@ export const Apis = ({ plansPromise }: Props) => {
         <div className="container mx-auto flex flex-col items-center gap-4 px-4 text-center sm:flex-row sm:justify-center">
           <p className="text-body-lg">{t('footer.description')}</p>
           <Button asChild size="lg" variant="secondary">
-            <a
-              href="https://api.nearblocks.io/api-docs"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
+            <a href={docsUrl} rel="noopener noreferrer" target="_blank">
               {t('footer.cta')}
               <ArrowUpRight className="mt-2 -ml-1 size-3 self-start" />
             </a>

--- a/apps/frontend/src/components/layout/api-deprecation-banner.tsx
+++ b/apps/frontend/src/components/layout/api-deprecation-banner.tsx
@@ -1,0 +1,61 @@
+'use client';
+
+import { X } from 'lucide-react';
+import { useEffect, useState } from 'react';
+
+import { useConfig } from '@/hooks/use-config';
+import { useLocale } from '@/hooks/use-locale';
+import { apiDocsUrl } from '@/lib/api-docs';
+
+const STORAGE_KEY = 'nb-api-v1v2-deprecation-dismissed';
+
+export const ApiDeprecationBanner = () => {
+  const { t } = useLocale('layout');
+  const network = useConfig((s) => s.config.network);
+  // Start hidden to avoid a hydration mismatch / flash; reveal after we can
+  // read the dismissed flag from localStorage on the client.
+  const [visible, setVisible] = useState(false);
+
+  useEffect(() => {
+    try {
+      setVisible(localStorage.getItem(STORAGE_KEY) !== '1');
+    } catch {
+      setVisible(true);
+    }
+  }, []);
+
+  if (!visible) return null;
+
+  const dismiss = () => {
+    try {
+      localStorage.setItem(STORAGE_KEY, '1');
+    } catch {
+      // Ignore storage failures (private mode, disabled storage, etc.)
+    }
+    setVisible(false);
+  };
+
+  return (
+    <div className="bg-muted text-muted-foreground border-border relative flex items-center justify-center border-b px-10 py-1.5 text-center">
+      <p className="text-body-xs">
+        {t('banner.apiDeprecation.message')}{' '}
+        <a
+          className="text-link underline underline-offset-2"
+          href={apiDocsUrl(network)}
+          rel="noopener noreferrer"
+          target="_blank"
+        >
+          {t('banner.apiDeprecation.link')}
+        </a>
+      </p>
+      <button
+        aria-label={t('banner.apiDeprecation.dismiss')}
+        className="absolute right-2 inline-flex cursor-pointer p-0.5 opacity-60 transition-opacity hover:opacity-100"
+        onClick={dismiss}
+        type="button"
+      >
+        <X className="size-3.5" />
+      </button>
+    </div>
+  );
+};

--- a/apps/frontend/src/components/layout/header.tsx
+++ b/apps/frontend/src/components/layout/header.tsx
@@ -6,6 +6,7 @@ import { useMemo } from 'react';
 
 import { Link } from '@/components/link';
 import { useConfig } from '@/hooks/use-config';
+import { apiDocsUrl } from '@/lib/api-docs';
 import { useLocale } from '@/hooks/use-locale';
 import { Logo } from '@/icons/logo';
 import { hrefForLocale } from '@/lib/locale';
@@ -82,7 +83,7 @@ const staticMenu = (isMainnet: boolean): NavMenu<RouteKey<'layout'>> => [
     menu: [
       { href: '/apis', key: 'menu.developers.apiPlans' },
       {
-        href: 'https://api.nearblocks.io/api-docs',
+        href: apiDocsUrl(isMainnet ? 'mainnet' : 'testnet'),
         key: 'menu.developers.apiDocs',
       },
       { divider: true },

--- a/apps/frontend/src/components/layout/index.tsx
+++ b/apps/frontend/src/components/layout/index.tsx
@@ -2,6 +2,7 @@ import { Suspense } from 'react';
 
 import { fetchStats, fetchSyncStatus } from '@/data/layout';
 
+import { ApiDeprecationBanner } from './api-deprecation-banner';
 import { Footer } from './footer';
 import { Formbricks } from './formbricks';
 import { Header } from './header';
@@ -19,6 +20,7 @@ export const Layout = ({ children }: Props) => {
 
   return (
     <>
+      <ApiDeprecationBanner />
       <Suspense fallback={null}>
         <Notice syncStatusPromise={syncStatusPromise} />
       </Suspense>

--- a/apps/frontend/src/components/page-heading.tsx
+++ b/apps/frontend/src/components/page-heading.tsx
@@ -4,15 +4,8 @@ import { Code2 } from 'lucide-react';
 import { ReactNode } from 'react';
 
 import { useConfig } from '@/hooks/use-config';
+import { apiDocsUrl } from '@/lib/api-docs';
 import { cn } from '@/lib/utils';
-
-const apiDocsUrl = (network: 'mainnet' | 'testnet', tag?: string) => {
-  const base =
-    network === 'mainnet'
-      ? 'https://api.nearblocks.io/api-docs'
-      : 'https://api-testnet.nearblocks.io/api-docs';
-  return tag ? `${base}#tag/${tag}` : base;
-};
 
 export const ApiBadge = ({
   className,

--- a/apps/frontend/src/lib/api-docs.ts
+++ b/apps/frontend/src/lib/api-docs.ts
@@ -1,0 +1,15 @@
+type Network = 'mainnet' | 'testnet';
+
+const API_BASE: Record<Network, string> = {
+  mainnet: 'https://api.nearblocks.io',
+  testnet: 'https://api-testnet.nearblocks.io',
+};
+
+/**
+ * Network-aware URL for the (current v3) API documentation.
+ * Optionally deep-links to a specific tag section.
+ */
+export const apiDocsUrl = (network: Network, tag?: string) => {
+  const base = `${API_BASE[network]}/api-docs`;
+  return tag ? `${base}#tag/${tag}` : base;
+};

--- a/apps/frontend/src/locales/en/layout.ts
+++ b/apps/frontend/src/locales/en/layout.ts
@@ -1,5 +1,10 @@
 export const layout = {
   banner: {
+    apiDeprecation: {
+      dismiss: 'Dismiss banner',
+      link: 'View the new API docs',
+      message: 'We’re updating our API.',
+    },
     newUi: {
       dismiss: 'Dismiss banner',
       feedbackLink: 'Send feedback',

--- a/apps/frontend/src/locales/es/layout.ts
+++ b/apps/frontend/src/locales/es/layout.ts
@@ -1,5 +1,10 @@
 export const layout = {
   banner: {
+    apiDeprecation: {
+      dismiss: 'Dismiss banner',
+      link: 'View the new API docs',
+      message: 'We’re updating our API.',
+    },
     newUi: {
       dismiss: 'Dismiss banner',
       feedbackLink: 'Send feedback',

--- a/apps/frontend/src/locales/fil-ph/layout.ts
+++ b/apps/frontend/src/locales/fil-ph/layout.ts
@@ -1,5 +1,10 @@
 export const layout = {
   banner: {
+    apiDeprecation: {
+      dismiss: 'Dismiss banner',
+      link: 'View the new API docs',
+      message: 'We’re updating our API.',
+    },
     newUi: {
       dismiss: 'Dismiss banner',
       feedbackLink: 'Send feedback',

--- a/apps/frontend/src/locales/fr/layout.ts
+++ b/apps/frontend/src/locales/fr/layout.ts
@@ -1,5 +1,10 @@
 export const layout = {
   banner: {
+    apiDeprecation: {
+      dismiss: 'Dismiss banner',
+      link: 'View the new API docs',
+      message: 'We’re updating our API.',
+    },
     newUi: {
       dismiss: 'Dismiss banner',
       feedbackLink: 'Send feedback',

--- a/apps/frontend/src/locales/id/layout.ts
+++ b/apps/frontend/src/locales/id/layout.ts
@@ -1,5 +1,10 @@
 export const layout = {
   banner: {
+    apiDeprecation: {
+      dismiss: 'Dismiss banner',
+      link: 'View the new API docs',
+      message: 'We’re updating our API.',
+    },
     newUi: {
       dismiss: 'Dismiss banner',
       feedbackLink: 'Send feedback',

--- a/apps/frontend/src/locales/it/layout.ts
+++ b/apps/frontend/src/locales/it/layout.ts
@@ -1,5 +1,10 @@
 export const layout = {
   banner: {
+    apiDeprecation: {
+      dismiss: 'Dismiss banner',
+      link: 'View the new API docs',
+      message: 'We’re updating our API.',
+    },
     newUi: {
       dismiss: 'Dismiss banner',
       feedbackLink: 'Send feedback',

--- a/apps/frontend/src/locales/ja/layout.ts
+++ b/apps/frontend/src/locales/ja/layout.ts
@@ -1,5 +1,10 @@
 export const layout = {
   banner: {
+    apiDeprecation: {
+      dismiss: 'Dismiss banner',
+      link: 'View the new API docs',
+      message: 'We’re updating our API.',
+    },
     newUi: {
       dismiss: 'Dismiss banner',
       feedbackLink: 'Send feedback',

--- a/apps/frontend/src/locales/ko/layout.ts
+++ b/apps/frontend/src/locales/ko/layout.ts
@@ -1,5 +1,10 @@
 export const layout = {
   banner: {
+    apiDeprecation: {
+      dismiss: 'Dismiss banner',
+      link: 'View the new API docs',
+      message: 'We’re updating our API.',
+    },
     newUi: {
       dismiss: 'Dismiss banner',
       feedbackLink: 'Send feedback',

--- a/apps/frontend/src/locales/ru/layout.ts
+++ b/apps/frontend/src/locales/ru/layout.ts
@@ -1,5 +1,10 @@
 export const layout = {
   banner: {
+    apiDeprecation: {
+      dismiss: 'Dismiss banner',
+      link: 'View the new API docs',
+      message: 'We’re updating our API.',
+    },
     newUi: {
       dismiss: 'Dismiss banner',
       feedbackLink: 'Send feedback',

--- a/apps/frontend/src/locales/th/layout.ts
+++ b/apps/frontend/src/locales/th/layout.ts
@@ -1,5 +1,10 @@
 export const layout = {
   banner: {
+    apiDeprecation: {
+      dismiss: 'Dismiss banner',
+      link: 'View the new API docs',
+      message: 'We’re updating our API.',
+    },
     newUi: {
       dismiss: 'Dismiss banner',
       feedbackLink: 'Send feedback',

--- a/apps/frontend/src/locales/uk/layout.ts
+++ b/apps/frontend/src/locales/uk/layout.ts
@@ -1,5 +1,10 @@
 export const layout = {
   banner: {
+    apiDeprecation: {
+      dismiss: 'Dismiss banner',
+      link: 'View the new API docs',
+      message: 'We’re updating our API.',
+    },
     newUi: {
       dismiss: 'Dismiss banner',
       feedbackLink: 'Send feedback',

--- a/apps/frontend/src/locales/vi/layout.ts
+++ b/apps/frontend/src/locales/vi/layout.ts
@@ -1,5 +1,10 @@
 export const layout = {
   banner: {
+    apiDeprecation: {
+      dismiss: 'Dismiss banner',
+      link: 'View the new API docs',
+      message: 'We’re updating our API.',
+    },
     newUi: {
       dismiss: 'Dismiss banner',
       feedbackLink: 'Send feedback',

--- a/apps/frontend/src/locales/zh-cn/layout.ts
+++ b/apps/frontend/src/locales/zh-cn/layout.ts
@@ -1,5 +1,10 @@
 export const layout = {
   banner: {
+    apiDeprecation: {
+      dismiss: 'Dismiss banner',
+      link: 'View the new API docs',
+      message: 'We’re updating our API.',
+    },
     newUi: {
       dismiss: 'Dismiss banner',
       feedbackLink: 'Send feedback',

--- a/apps/frontend/src/locales/zh-hk/layout.ts
+++ b/apps/frontend/src/locales/zh-hk/layout.ts
@@ -1,5 +1,10 @@
 export const layout = {
   banner: {
+    apiDeprecation: {
+      dismiss: 'Dismiss banner',
+      link: 'View the new API docs',
+      message: 'We’re updating our API.',
+    },
     newUi: {
       dismiss: 'Dismiss banner',
       feedbackLink: 'Send feedback',


### PR DESCRIPTION
Frontend:
- add a quiet, dismissible, site-wide banner pointing developers to the new API docs ("We're updating our API." — calm wording, no version specifics); copy added to all locale dictionaries
- extract a shared network-aware `apiDocsUrl` helper and use it for the nav link, the /apis page links and the per-page API badge, so testnet resolves to api-testnet.nearblocks.io and mainnet to api.nearblocks.io

API docs (apps/api):
- surface the v1/v2 deprecation as a prominent callout at the top of both /api-docs and /api-docs/legacy (light/dark aware)
- simplify attribution wording: required on the free plan only; paid plans are exempt
