### PR TITLE
feat(api): add usage events

### DIFF
--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -12,6 +12,7 @@ import apiDocumentation from '#libs/apiDocumentation';
 import logger from '#libs/logger';
 import sentry from '#libs/sentry';
 import { anonymousStrategy, bearerStrategy } from '#middlewares/passport';
+import { usageEvents } from '#middlewares/usageEvents';
 import routes from '#routes/index';
 import routesV2 from '#routes/v2/index';
 import routesV3 from '#routes/v3/index';
@@ -54,6 +55,8 @@ passport.use(anonymousStrategy);
 
 app.set('trust proxy', 2);
 app.get('/ip', (req, res) => res.send(req.ip));
+
+app.use(usageEvents);
 
 app.use('/v1', routes());
 app.use('/v2', routesV2());

--- a/apps/api/src/config.ts
+++ b/apps/api/src/config.ts
@@ -1,4 +1,4 @@
-import { cleanEnv, str, url } from 'envalid';
+import { cleanEnv, num, str, url } from 'envalid';
 
 import { Network } from 'nb-types';
 
@@ -39,6 +39,9 @@ const env = cleanEnv(process.env, {
   RPC_URL: str(),
   SENTRY_DSN: str({ default: '' }),
   TESTNET_URL: str({ default: 'https://api-testnet.nearblocks.io' }),
+  // Hard ceiling on the buffered usage events; bounds memory if the
+  // consumer stalls. ~500k events ≈ tens of MB. Set 0 to disable capture.
+  USAGE_STREAM_MAXLEN: num({ default: 500_000 }),
 });
 
 const baseStart =
@@ -90,6 +93,7 @@ const config: Config = {
   sentryDsn: env.SENTRY_DSN,
   stakingStart,
   testnetUrl: env.TESTNET_URL,
+  usageStreamMaxLen: env.USAGE_STREAM_MAXLEN,
   userDbUrl: env.DB_URL_USER,
 };
 

--- a/apps/api/src/middlewares/rateLimiter.ts
+++ b/apps/api/src/middlewares/rateLimiter.ts
@@ -125,6 +125,7 @@ const rateLimiter = catchAsync(
     // Validators endpoint always counts as 1 query regardless of per_page
     const consumeCount =
       baseUrl === '/validators' ? 1 : Math.ceil(+perPage / 25);
+    res.locals.usageCredits = consumeCount;
 
     try {
       if (keyId) {
@@ -182,6 +183,7 @@ const useFreePlan = async (
   const perPage = req?.query?.per_page || 25;
   // Validators endpoint always counts as 1 query regardless of per_page
   const consumeCount = baseUrl === '/validators' ? 1 : Math.ceil(+perPage / 25);
+  res.locals.usageCredits = consumeCount;
 
   const plan = await getPlan(baseUrl, token);
 

--- a/apps/api/src/middlewares/usageEvents.ts
+++ b/apps/api/src/middlewares/usageEvents.ts
@@ -1,5 +1,6 @@
 import { NextFunction, Request, Response } from 'express';
 
+import config from '#config';
 import logger from '#libs/logger';
 import { ratelimiterRedisClient } from '#libs/ratelimiterRedis';
 
@@ -9,7 +10,6 @@ import { ratelimiterRedisClient } from '#libs/ratelimiterRedis';
  * never throws into the request path; the cap keeps it bounded.
  */
 const STREAM_KEY = 'api:usage:events';
-const STREAM_MAXLEN = 1_000_000;
 
 type UsageUser = { id?: number; key_id?: number };
 
@@ -23,6 +23,9 @@ export const usageEvents = (
   res: Response,
   next: NextFunction,
 ) => {
+  // Kill-switch: set USAGE_STREAM_MAXLEN=0 to disable capture entirely.
+  if (config.usageStreamMaxLen <= 0) return next();
+
   const start = process.hrtime.bigint();
 
   res.on('finish', () => {
@@ -52,7 +55,7 @@ export const usageEvents = (
           STREAM_KEY,
           'MAXLEN',
           '~',
-          STREAM_MAXLEN,
+          config.usageStreamMaxLen,
           '*',
           'd',
           JSON.stringify(event),

--- a/apps/api/src/middlewares/usageEvents.ts
+++ b/apps/api/src/middlewares/usageEvents.ts
@@ -1,0 +1,70 @@
+import { NextFunction, Request, Response } from 'express';
+
+import logger from '#libs/logger';
+import { ratelimiterRedisClient } from '#libs/ratelimiterRedis';
+
+/**
+ * Records a lightweight usage event per request to a capped Redis stream for
+ * out-of-band aggregation. Fire-and-forget: never blocks the response and
+ * never throws into the request path; the cap keeps it bounded.
+ */
+const STREAM_KEY = 'api:usage:events';
+const STREAM_MAXLEN = 1_000_000;
+
+type UsageUser = { id?: number; key_id?: number };
+
+const versionOf = (url: string): null | string => {
+  const match = /^\/(v[123])(?:\/|$)/.exec(url);
+  return match ? match[1] : null;
+};
+
+export const usageEvents = (
+  req: Request,
+  res: Response,
+  next: NextFunction,
+) => {
+  const start = process.hrtime.bigint();
+
+  res.on('finish', () => {
+    try {
+      const user = req.user as undefined | UsageUser;
+      // Normalized route pattern (e.g. /v1/blocks/:hash), not the raw URL.
+      const pattern =
+        (req.baseUrl || '') +
+        (req.route?.path && req.route.path !== '/' ? req.route.path : '');
+
+      const event = {
+        credits: (res.locals?.usageCredits as number | undefined) ?? null,
+        ip: req.ip ?? null,
+        key_id: user?.key_id ?? null,
+        method: req.method,
+        ms: Number((process.hrtime.bigint() - start) / 1_000_000n),
+        path: req.originalUrl.split('?')[0],
+        route: pattern || req.path,
+        status: res.statusCode,
+        t: Date.now(),
+        user_id: user?.id ?? null,
+        version: versionOf(req.originalUrl),
+      };
+
+      void ratelimiterRedisClient
+        .xadd(
+          STREAM_KEY,
+          'MAXLEN',
+          '~',
+          STREAM_MAXLEN,
+          '*',
+          'd',
+          JSON.stringify(event),
+        )
+        .catch(() => {
+          // Best-effort: never surface stream errors to the request path.
+        });
+    } catch (error) {
+      // Usage capture must never affect request handling.
+      logger.error(error);
+    }
+  });
+
+  next();
+};

--- a/apps/api/src/types/types.ts
+++ b/apps/api/src/types/types.ts
@@ -52,6 +52,7 @@ export type Config = {
   sentryDsn?: string;
   stakingStart: bigint;
   testnetUrl: string;
+  usageStreamMaxLen: number;
   userDbUrl: string;
 };
 


### PR DESCRIPTION
Global post-response middleware that XADDs one usage event per request (key_id, user_id, version, route pattern, raw path, method, status, ip, duration, optional credits) to a capped stream (api:usage:events, MAXLEN ~1M) on the rate-limiter Redis/Dragonfly.

Fire-and-forget, non-blocking, never throws into the request path; the stream is capped so a lagging/absent consumer can't grow it unbounded. A scheduled Laravel command drains it into the TimescaleDB firehose, so the API has no coupling to that DB.

credits is read from res.locals.usageCredits when present; the rate limiter already computes consumeCount and can set it in a one-line follow-up.
