### PR TITLE
feat(api): record network on usage events

### DIFF
--- a/apps/api/src/middlewares/usageEvents.ts
+++ b/apps/api/src/middlewares/usageEvents.ts
@@ -42,6 +42,7 @@ export const usageEvents = (
         key_id: user?.key_id ?? null,
         method: req.method,
         ms: Number((process.hrtime.bigint() - start) / 1_000_000n),
+        network: config.network,
         path: req.originalUrl.split('?')[0],
         route: pattern || req.path,
         status: res.statusCode,


### PR DESCRIPTION
Adds the deployment network to each usage event so mainnet and testnet traffic (which share the stream) can be told apart downstream.
