### PR TITLE
fix(frontend): render array args and decode result on txn execution tab

### DIFF
--- a/apps/frontend/src/components/json-tree.tsx
+++ b/apps/frontend/src/components/json-tree.tsx
@@ -3,6 +3,8 @@
 import { ChevronDown, ChevronRight } from 'lucide-react';
 import { useState } from 'react';
 
+import { Copy } from '@/components/copy';
+
 type Json =
   | { [k: string]: Json }
   | boolean
@@ -28,7 +30,9 @@ const Primitive = ({ value }: { value: Json }) => {
     return <span className="text-[var(--prism-number)]">{value}</span>;
   if (typeof value === 'string')
     return (
-      <span className="text-[var(--prism-string)]">&quot;{value}&quot;</span>
+      <span className="break-all text-[var(--prism-string)]">
+        &quot;{value}&quot;
+      </span>
     );
   return null;
 };
@@ -95,34 +99,43 @@ const Node = ({ depth = 0, isLast = true, name, value }: NodeProps) => {
   const closeBracket = isArr ? ']' : '}';
 
   return (
-    <div className="leading-relaxed">
-      <span
-        className="inline-flex cursor-pointer items-center select-none"
-        onClick={empty ? undefined : () => setOpen((p) => !p)}
-      >
+    <div className="group/node leading-relaxed">
+      <span className="inline-flex max-w-full items-center">
+        <span
+          className="inline-flex cursor-pointer items-center select-none"
+          onClick={empty ? undefined : () => setOpen((p) => !p)}
+        >
+          {!empty && (
+            <span className="text-muted-foreground/60 -ml-3.5 inline-flex w-3.5">
+              {open$ ? (
+                <ChevronDown className="size-3.5" />
+              ) : (
+                <ChevronRight className="size-3.5" />
+              )}
+            </span>
+          )}
+          {label}
+          <Punct>{openBracket}</Punct>
+          {!open$ && (
+            <>
+              {!empty && (
+                <span className="text-muted-foreground/60 mx-1">
+                  {isArr
+                    ? `${items.length} item${items.length === 1 ? '' : 's'}`
+                    : `${items.length} field${items.length === 1 ? '' : 's'}`}
+                </span>
+              )}
+              <Punct>{closeBracket}</Punct>
+              {!isLast && <Punct>,</Punct>}
+            </>
+          )}
+        </span>
         {!empty && (
-          <span className="text-muted-foreground/60 -ml-3.5 inline-flex w-3.5">
-            {open$ ? (
-              <ChevronDown className="size-3.5" />
-            ) : (
-              <ChevronRight className="size-3.5" />
-            )}
-          </span>
-        )}
-        {label}
-        <Punct>{openBracket}</Punct>
-        {!open$ && (
-          <>
-            {!empty && (
-              <span className="text-muted-foreground/60 mx-1">
-                {isArr
-                  ? `${items.length} item${items.length === 1 ? '' : 's'}`
-                  : `${items.length} field${items.length === 1 ? '' : 's'}`}
-              </span>
-            )}
-            <Punct>{closeBracket}</Punct>
-            {!isLast && <Punct>,</Punct>}
-          </>
+          <Copy
+            className="ml-1 size-5 opacity-0 transition-opacity group-hover/node:opacity-100"
+            size="icon-xs"
+            text={JSON.stringify(value, null, 2)}
+          />
         )}
       </span>
       {open$ && (
@@ -155,7 +168,7 @@ type Props = {
 
 export const JsonTree = ({ className, value }: Props) => (
   <div
-    className={`prism-code text-body-sm py-2 pr-4 pl-8 font-mono ${
+    className={`prism-code text-body-sm min-w-0 py-2 pr-4 pl-8 font-mono break-words ${
       className ?? ''
     }`}
   >

--- a/apps/frontend/src/components/json-tree.tsx
+++ b/apps/frontend/src/components/json-tree.tsx
@@ -73,10 +73,21 @@ const Node = ({ depth = 0, isLast = true, name, value }: NodeProps) => {
 
   if (!collapsible) {
     return (
-      <div className="leading-relaxed">
-        {label}
-        <Primitive value={value} />
-        {!isLast && <Punct>,</Punct>}
+      <div className="group/node leading-relaxed">
+        <span className="inline-flex max-w-full items-center">
+          <span className="inline-flex items-center">
+            {label}
+            <Primitive value={value} />
+            {!isLast && <Punct>,</Punct>}
+          </span>
+          {value !== null && value !== undefined && (
+            <Copy
+              className="ml-1 size-5 opacity-0 transition-opacity group-hover/node:opacity-100"
+              size="icon-xs"
+              text={String(value)}
+            />
+          )}
+        </span>
       </div>
     );
   }

--- a/apps/frontend/src/components/txns/txn/actions/action.tsx
+++ b/apps/frontend/src/components/txns/txn/actions/action.tsx
@@ -128,9 +128,19 @@ export const Action = ({
   }
 
   if (action.action === ActionKind.DEPLOY_CONTRACT) {
+    const codeHash =
+      typeof args.code_hash === 'string' ? args.code_hash : undefined;
     return (
       <span className="text-body-sm flex flex-wrap items-center gap-1">
         {t('actions.deployContract')}
+        {codeHash && (
+          <>
+            <Badge variant="gray">
+              <code className="max-w-32 truncate sm:max-w-40">{codeHash}</code>
+            </Badge>
+            <Copy className="text-muted-foreground" text={codeHash} />
+          </>
+        )}
         {full && (
           <>
             {' '}

--- a/apps/frontend/src/components/txns/txn/actions/action.tsx
+++ b/apps/frontend/src/components/txns/txn/actions/action.tsx
@@ -162,9 +162,21 @@ export const Action = ({
     action.action === ActionKind.USE_GLOBAL_CONTRACT ||
     action.action === ActionKind.USE_GLOBAL_CONTRACT_BY_ACCOUNT_ID
   ) {
+    // The first three carry a code_hash; the fourth (USE_..._BY_ACCOUNT_ID)
+    // carries an account_id instead — the guard naturally skips that case.
+    const codeHash =
+      typeof args.code_hash === 'string' ? args.code_hash : undefined;
     return (
       <span className="text-body-sm flex flex-wrap items-center gap-1">
         {t('actions.deployGlobalContract')}
+        {codeHash && (
+          <>
+            <Badge variant="gray">
+              <code className="max-w-32 truncate sm:max-w-40">{codeHash}</code>
+            </Badge>
+            <Copy className="text-muted-foreground" text={codeHash} />
+          </>
+        )}
         {full && (
           <>
             {' '}

--- a/apps/frontend/src/components/txns/txn/execution/action.tsx
+++ b/apps/frontend/src/components/txns/txn/execution/action.tsx
@@ -1,92 +1,19 @@
 'use client';
 
-import { useContext, useMemo, useState } from 'react';
+import type { JsonData } from 'nb-schemas/src/common';
+import { useContext, useMemo } from 'react';
 
 import type { ActionReceipt, TxnReceipt } from 'nb-schemas';
 import { ActionKind } from 'nb-types';
-
-import { Button } from '@/ui/button';
 
 import { Action, argsRecord } from '../actions/action';
 import { ReceiptIcon } from '../actions/icon';
 import { AuroraArgsViewer } from './aurora';
 import { CodeViewer } from './code';
 import { RpcContext } from './context';
+import { hasJsonValue } from './encode';
+import { EncodedData } from './encoded-data';
 import { deepUnescape, findRawArgs, isAuroraAction } from './utils';
-
-type Encoding = 'base64' | 'hex' | 'json' | 'raw' | 'utf8';
-
-const ENCODINGS: { label: string; value: Encoding }[] = [
-  { label: 'JSON', value: 'json' },
-  { label: 'UTF-8', value: 'utf8' },
-  { label: 'Hex', value: 'hex' },
-  { label: 'Base64', value: 'base64' },
-  { label: 'Raw', value: 'raw' },
-];
-
-const base64ToBytes = (b64: string): null | Uint8Array => {
-  try {
-    const bin = atob(b64);
-    const bytes = new Uint8Array(bin.length);
-    for (let i = 0; i < bin.length; i++) bytes[i] = bin.charCodeAt(i);
-    return bytes;
-  } catch {
-    return null;
-  }
-};
-
-const utf8ToBytes = (text: string): Uint8Array =>
-  new TextEncoder().encode(text);
-
-const bytesToUtf8 = (bytes: Uint8Array): string =>
-  new TextDecoder('utf-8', { fatal: false }).decode(bytes);
-
-const bytesToHex = (bytes: Uint8Array): string =>
-  Array.from(bytes)
-    .map((b) => b.toString(16).padStart(2, '0'))
-    .join('');
-
-const bytesToBase64 = (bytes: Uint8Array): string => {
-  let bin = '';
-  for (let i = 0; i < bytes.length; i++) bin += String.fromCharCode(bytes[i]);
-  return btoa(bin);
-};
-
-const encodeArgs = (
-  encoding: Encoding,
-  argsBase64: string | undefined,
-  decoded: Record<string, unknown> | undefined,
-  hasArgs: boolean,
-): string => {
-  try {
-    const bytes = argsBase64
-      ? base64ToBytes(argsBase64)
-      : hasArgs && decoded
-      ? utf8ToBytes(JSON.stringify(deepUnescape(decoded)))
-      : null;
-
-    if (encoding === 'json') {
-      if (hasArgs && decoded) {
-        return JSON.stringify(deepUnescape(decoded), null, 2);
-      }
-      if (bytes) {
-        const text = bytesToUtf8(bytes);
-        try {
-          return JSON.stringify(JSON.parse(text), null, 2);
-        } catch {
-          return text;
-        }
-      }
-      return '';
-    }
-    if (!bytes) return '<invalid encoding>';
-    if (encoding === 'utf8') return bytesToUtf8(bytes);
-    if (encoding === 'hex') return bytesToHex(bytes);
-    return bytesToBase64(bytes);
-  } catch {
-    return '<unable to decode args>';
-  }
-};
 
 type Props = {
   action: ActionReceipt;
@@ -101,83 +28,63 @@ export const ReceiptAction = ({
   onlyArgs = false,
   receipt,
 }: Props) => {
-  const [encoding, setEncoding] = useState<Encoding>('json');
   const { enableRpc, rpcData, rpcLoading } = useContext(RpcContext);
 
-  const { args, argsBase64, hasArgs, method } = useMemo(() => {
-    const args = argsRecord(action.args);
+  const { argsBase64, argsValue, hasArgs, method } = useMemo(() => {
+    const wrapper = argsRecord(action.args);
     let method: string | undefined =
       typeof action.method === 'string' ? action.method : undefined;
-    let hasArgs = Object.keys(args).length > 0;
-    let argsJson: Record<string, unknown> | undefined;
+    // For function calls the indexer wraps args as { args_json, args_base64,
+    // method_name, ... }. `args_json` may be any JSON value — including a
+    // top-level array — so it must not be coerced to a record. For every other
+    // action kind the raw args object is shown as-is.
+    let argsValue: JsonData | undefined;
     let argsBase64: string | undefined;
 
     if (action.action === ActionKind.FUNCTION_CALL) {
-      if (Object.keys(args).length > 0) {
-        if (!method && 'method_name' in args) {
-          method = args.method_name as string;
-        }
-        argsBase64 =
-          typeof args.args_base64 === 'string'
-            ? (args.args_base64 as string)
-            : undefined;
-        argsJson = argsRecord(args.args_json);
-        hasArgs = Object.keys(argsJson).length > 0;
+      if (!method && typeof wrapper.method_name === 'string') {
+        method = wrapper.method_name;
       }
+      argsBase64 =
+        typeof wrapper.args_base64 === 'string'
+          ? wrapper.args_base64
+          : undefined;
+      argsValue = wrapper.args_json ?? undefined;
+    } else {
+      argsValue = action.args ?? undefined;
     }
 
-    return { args: argsJson ?? args, argsBase64, hasArgs, method };
+    return { argsBase64, argsValue, hasArgs: hasJsonValue(argsValue), method };
   }, [action]);
 
   const isAurora = isAuroraAction(method, receipt.receiver_account_id);
   const showEncodingToggle = !!method && (!!argsBase64 || hasArgs);
   const rawArgs = findRawArgs(rpcData, receipt.receipt_id, index);
   const rawCode = rawArgs ?? (rpcLoading ? 'Loading...' : 'No data');
-  const displayCode = showEncodingToggle
-    ? encoding === 'raw'
-      ? rawCode
-      : encodeArgs(encoding, argsBase64, args, hasArgs)
-    : hasArgs
-    ? JSON.stringify(deepUnescape(args), null, 2)
-    : argsBase64;
-
-  const onEncodingClick = (value: Encoding) => {
-    setEncoding(value);
-    if (value === 'raw' && !rpcData) enableRpc();
-  };
 
   const codeBlock =
     isAurora && argsBase64 ? (
       <AuroraArgsViewer argsBase64={argsBase64} method={method!} />
-    ) : (
-      displayCode && (
-        <CodeViewer
-          className="min-h-17"
-          code={displayCode}
-          language={encoding === 'json' ? 'json' : 'plain'}
-          showByteSize
-          toolbar={
-            showEncodingToggle && (
-              <>
-                {ENCODINGS.map(({ label, value }) => (
-                  <Button
-                    className="cursor-pointer border-0"
-                    key={value}
-                    onClick={() => onEncodingClick(value)}
-                    size="xs"
-                    variant={encoding === value ? 'secondary' : 'outline'}
-                  >
-                    {label}
-                  </Button>
-                ))}
-              </>
-            )
-          }
-          tree={encoding === 'json'}
-          wrap={encoding !== 'json'}
-        />
-      )
-    );
+    ) : showEncodingToggle ? (
+      <EncodedData
+        base64={argsBase64}
+        className="min-h-17"
+        json={argsValue}
+        onRawSelect={() => {
+          if (!rpcData) enableRpc();
+        }}
+        rawCode={rawCode}
+      />
+    ) : hasArgs ? (
+      <CodeViewer
+        className="min-h-17"
+        code={JSON.stringify(deepUnescape(argsValue), null, 2)}
+        showByteSize
+        tree
+      />
+    ) : argsBase64 ? (
+      <CodeViewer className="min-h-17" code={argsBase64} showByteSize />
+    ) : null;
 
   if (onlyArgs) {
     return <>{codeBlock}</>;

--- a/apps/frontend/src/components/txns/txn/execution/encode.ts
+++ b/apps/frontend/src/components/txns/txn/execution/encode.ts
@@ -1,0 +1,78 @@
+import { deepUnescape } from './utils';
+
+export type Encoding = 'base64' | 'hex' | 'json' | 'raw' | 'utf8';
+
+export const base64ToBytes = (b64: string): null | Uint8Array => {
+  try {
+    const bin = atob(b64);
+    const bytes = new Uint8Array(bin.length);
+    for (let i = 0; i < bin.length; i++) bytes[i] = bin.charCodeAt(i);
+    return bytes;
+  } catch {
+    return null;
+  }
+};
+
+export const utf8ToBytes = (text: string): Uint8Array =>
+  new TextEncoder().encode(text);
+
+export const bytesToUtf8 = (bytes: Uint8Array): string =>
+  new TextDecoder('utf-8', { fatal: false }).decode(bytes);
+
+export const bytesToHex = (bytes: Uint8Array): string =>
+  Array.from(bytes)
+    .map((b) => b.toString(16).padStart(2, '0'))
+    .join('');
+
+export const bytesToBase64 = (bytes: Uint8Array): string => {
+  let bin = '';
+  for (let i = 0; i < bytes.length; i++) bin += String.fromCharCode(bytes[i]);
+  return btoa(bin);
+};
+
+// Treats arrays and objects as "having content" only when non-empty;
+// primitives (string/number/boolean) always count, null/undefined never do.
+export const hasJsonValue = (value: unknown): boolean => {
+  if (value === null || value === undefined) return false;
+  if (Array.isArray(value)) return value.length > 0;
+  if (typeof value === 'object') return Object.keys(value).length > 0;
+  return true;
+};
+
+// Renders a value in the requested encoding. `value` is already-decoded JSON
+// (object, array, or primitive); `base64` is the raw byte payload when present.
+// Either source may be supplied — `value` is preferred for JSON, `base64` for
+// the byte-oriented encodings.
+export const encodeValue = (
+  encoding: Exclude<Encoding, 'raw'>,
+  base64: string | undefined,
+  value: unknown,
+  hasValue: boolean,
+): string => {
+  try {
+    const bytes = base64
+      ? base64ToBytes(base64)
+      : hasValue
+      ? utf8ToBytes(JSON.stringify(deepUnescape(value)))
+      : null;
+
+    if (encoding === 'json') {
+      if (hasValue) return JSON.stringify(deepUnescape(value), null, 2);
+      if (bytes) {
+        const text = bytesToUtf8(bytes);
+        try {
+          return JSON.stringify(JSON.parse(text), null, 2);
+        } catch {
+          return text;
+        }
+      }
+      return '';
+    }
+    if (!bytes) return '<invalid encoding>';
+    if (encoding === 'utf8') return bytesToUtf8(bytes);
+    if (encoding === 'hex') return bytesToHex(bytes);
+    return bytesToBase64(bytes);
+  } catch {
+    return '<unable to decode>';
+  }
+};

--- a/apps/frontend/src/components/txns/txn/execution/encoded-data.tsx
+++ b/apps/frontend/src/components/txns/txn/execution/encoded-data.tsx
@@ -1,0 +1,77 @@
+'use client';
+
+import type { JsonData } from 'nb-schemas/src/common';
+import { useState } from 'react';
+
+import { Button } from '@/ui/button';
+
+import { CodeViewer } from './code';
+import { encodeValue, type Encoding, hasJsonValue } from './encode';
+
+const ENCODINGS: { label: string; value: Encoding }[] = [
+  { label: 'JSON', value: 'json' },
+  { label: 'UTF-8', value: 'utf8' },
+  { label: 'Hex', value: 'hex' },
+  { label: 'Base64', value: 'base64' },
+];
+
+type Props = {
+  base64?: string;
+  className?: string;
+  defaultEncoding?: Encoding;
+  json?: JsonData;
+  // When provided, a "Raw" toggle is shown. `rawCode` is the content to render
+  // for it, and `onRawSelect` is fired when the user picks it (e.g. to fetch
+  // the original payload over RPC).
+  onRawSelect?: () => void;
+  rawCode?: string;
+};
+
+export const EncodedData = ({
+  base64,
+  className,
+  defaultEncoding = 'json',
+  json,
+  onRawSelect,
+  rawCode,
+}: Props) => {
+  const [encoding, setEncoding] = useState<Encoding>(defaultEncoding);
+  const hasValue = hasJsonValue(json);
+  const showRaw = rawCode !== undefined || !!onRawSelect;
+
+  const encodings = showRaw
+    ? [...ENCODINGS, { label: 'Raw', value: 'raw' as Encoding }]
+    : ENCODINGS;
+
+  const code =
+    encoding === 'raw'
+      ? rawCode ?? ''
+      : encodeValue(encoding, base64, json, hasValue);
+
+  const onClick = (value: Encoding) => {
+    setEncoding(value);
+    if (value === 'raw') onRawSelect?.();
+  };
+
+  return (
+    <CodeViewer
+      className={className}
+      code={code}
+      language={encoding === 'json' ? 'json' : 'plain'}
+      showByteSize
+      toolbar={encodings.map(({ label, value }) => (
+        <Button
+          className="cursor-pointer border-0"
+          key={value}
+          onClick={() => onClick(value)}
+          size="xs"
+          variant={encoding === value ? 'secondary' : 'outline'}
+        >
+          {label}
+        </Button>
+      ))}
+      tree={encoding === 'json'}
+      wrap={encoding !== 'json'}
+    />
+  );
+};

--- a/apps/frontend/src/components/txns/txn/execution/output.tsx
+++ b/apps/frontend/src/components/txns/txn/execution/output.tsx
@@ -13,7 +13,7 @@ import { useLocale } from '@/hooks/use-locale';
 import { Skeleton } from '@/ui/skeleton';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/ui/tooltip';
 
-import { CodeViewer } from './code';
+import { EncodedData } from './encoded-data';
 import { ReceiptLogs } from './logs';
 
 const collectReceiptIds = (
@@ -89,14 +89,18 @@ export const ReceiptOutputRows = ({ loading = false, receipt }: Props) => {
                     </span>
                   );
                 }
+                // A SUCCESS_VALUE result is the contract's base64-encoded
+                // return value — decode it so JSON/UTF-8/Hex/Base64 views all
+                // work. Any other (already-structured) result is passed as-is.
+                const isSuccessValue =
+                  statusKey === ExecutionOutcomeStatus.SUCCESS_VALUE &&
+                  typeof result === 'string';
+
                 return (
-                  <CodeViewer
+                  <EncodedData
+                    base64={isSuccessValue ? (result as string) : undefined}
                     className="min-h-12"
-                    code={
-                      typeof result === 'string'
-                        ? result
-                        : JSON.stringify(result, null, 2)
-                    }
+                    json={isSuccessValue ? undefined : result}
                   />
                 );
               }}

--- a/apps/frontend/src/components/txns/txn/index.tsx
+++ b/apps/frontend/src/components/txns/txn/index.tsx
@@ -1,10 +1,12 @@
 'use client';
 
 import { RiQuestionLine } from '@remixicon/react';
+import { Radio } from 'lucide-react';
 import { useRouter } from 'next/navigation';
 import { use, useEffect } from 'react';
 
 import { Stats, Txn, TxnFT, TxnMT, TxnNFT, TxnReceipt } from 'nb-schemas';
+import { ActionKind } from 'nb-types';
 
 import { Copy } from '@/components/copy';
 import { AccountLink, Link } from '@/components/link';
@@ -21,10 +23,12 @@ import {
   nearFormat,
   numberFormat,
 } from '@/lib/format';
+import { Badge } from '@/ui/badge';
 import { Card, CardContent } from '@/ui/card';
 import { Skeleton } from '@/ui/skeleton';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/ui/tooltip';
 
+import { argsRecord } from './actions/action';
 import { Transfers } from './transfers';
 
 type Props = {
@@ -228,17 +232,56 @@ export const Overview = ({
               {t('overview.from')}
             </ListLeft>
             <ListRight>
-              <p className="flex items-center gap-1">
+              <p className="flex flex-wrap items-center gap-1">
                 <SkeletonSlot
                   fallback={<Skeleton className="h-7 w-30" />}
                   loading={loading || !txn}
                 >
-                  {() => (
-                    <AccountLink
-                      account={txn!.signer_account_id}
-                      textClassName="max-w-60"
-                    />
-                  )}
+                  {() => {
+                    // Meta-transaction: the on-chain signer is the relayer.
+                    // The real sender lives inside the DelegateAction's args.
+                    const delegate = txn!.actions?.find(
+                      (a) => a.action === ActionKind.DELEGATE_ACTION,
+                    );
+                    const delegateArgs = delegate
+                      ? argsRecord(delegate.args)
+                      : null;
+                    const realSender =
+                      delegateArgs && typeof delegateArgs.sender_id === 'string'
+                        ? delegateArgs.sender_id
+                        : null;
+
+                    return (
+                      <>
+                        <AccountLink
+                          account={realSender ?? txn!.signer_account_id}
+                          textClassName="max-w-60"
+                        />
+                        {realSender && (
+                          <Tooltip>
+                            <TooltipTrigger asChild>
+                              <Badge
+                                className="inline-flex cursor-help items-center gap-1"
+                                variant="gray"
+                              >
+                                <Radio className="size-3" />
+                                via
+                                <Link
+                                  className="text-link max-w-32 truncate sm:max-w-40"
+                                  href={`/address/${txn!.signer_account_id}`}
+                                >
+                                  {txn!.signer_account_id}
+                                </Link>
+                              </Badge>
+                            </TooltipTrigger>
+                            <TooltipContent>
+                              Meta-transaction relayed on behalf of the sender
+                            </TooltipContent>
+                          </Tooltip>
+                        )}
+                      </>
+                    );
+                  }}
                 </SkeletonSlot>
               </p>
             </ListRight>


### PR DESCRIPTION
- Stop coercing array-shaped function-call args to {}; calls whose args_json is a top-level array (e.g. return_ck_and_clean_state_on_success) rendered blank and now display correctly
- Decode SUCCESS_VALUE results from base64 and offer a JSON/UTF-8/Hex/Base64 toggle, via a shared EncodedData component and extracted encode helpers
- Add per-node hover copy icons to the JSON tree
- Wrap long keys/values so they no longer force horizontal scroll on mobile
