### PR TITLE
fix(api): stop free-plan fallback poisoning user_plan cache; log demo…

### DIFF
--- a/apps/api/src/middlewares/passport.ts
+++ b/apps/api/src/middlewares/passport.ts
@@ -48,7 +48,14 @@ const bearerVerify: VerifyFunction = async (token, done) => {
 
     return done(null, false);
   } catch (error) {
-    logger.error(error);
+    // Auth lookup failed (e.g. DB unreachable / stale connection). Falling back
+    // to anonymous means every affected request degrades to free-tier limits —
+    // when this fires fleet-wide it's the signature of an outage (all customers
+    // 429), not a bad token. Log it explicitly so it can't hide as silent noise.
+    logger.error(
+      error,
+      'auth: token lookup failed, treating request as anonymous',
+    );
     return done(null, false);
   }
 };

--- a/apps/api/src/middlewares/passport.ts
+++ b/apps/api/src/middlewares/passport.ts
@@ -46,16 +46,15 @@ const bearerVerify: VerifyFunction = async (token, done) => {
       return done(null, user);
     }
 
+    // Token supplied but no matching user. A spike = silent mass demotion to free.
+    logger.warn(
+      { token: token.slice(0, 6) },
+      'auth: bearer token did not resolve to a user, treating as anonymous',
+    );
     return done(null, false);
   } catch (error) {
-    // Auth lookup failed (e.g. DB unreachable / stale connection). Falling back
-    // to anonymous means every affected request degrades to free-tier limits —
-    // when this fires fleet-wide it's the signature of an outage (all customers
-    // 429), not a bad token. Log it explicitly so it can't hide as silent noise.
-    logger.error(
-      error,
-      'auth: token lookup failed, treating request as anonymous',
-    );
+    // Auth lookup errored (DB/redis) -> anonymous. A spike = fleet-wide outage.
+    logger.error(error, 'auth: token lookup failed, treating request as anonymous');
     return done(null, false);
   }
 };

--- a/apps/api/src/middlewares/rateLimiter.ts
+++ b/apps/api/src/middlewares/rateLimiter.ts
@@ -107,13 +107,25 @@ const rateLimiter = catchAsync(
           );
         }
       } catch (error) {
-        logger.error(error); // plan lookup failed — visibility into free-plan fallback
+        // Plan lookup failed (e.g. DB unreachable / stale connection). The user
+        // is demoted to free-tier; if this fires fleet-wide it's an outage, not
+        // a per-customer issue — log loudly with context.
+        logger.error(
+          error,
+          `rate limit: plan lookup failed for user ${id}, applying free plan`,
+        );
 
         return await useFreePlan(req, res, next, req.ip!);
       }
     }
 
     if (!selectedPlan) {
+      // Authenticated user resolved to no active plan -> free-tier limits.
+      // Expected for genuinely free accounts, but a spike across many users is
+      // the signature of a plan-resolution/DB outage (paying customers silently
+      // demoted and 429'd fleet-wide), so make it visible.
+      logger.warn(`rate limit: no active plan for user ${id}, applying free plan`);
+
       if (keyId) {
         const tokenKey = getTokenKey(id, keyId);
         return await useFreePlan(req, res, next, id, tokenKey);
@@ -200,16 +212,13 @@ const useFreePlan = async (
 
   const plan = await getPlan(baseUrl, token);
 
-  try {
-    await ratelimiterRedisClient.set(
-      `user_plan:${key}`,
-      JSON.stringify(plan),
-      'EX',
-      86400,
-    );
-  } catch (redisError) {
-    // logger.error(redisError, 'Error caching user plan in Redis.');
-  }
+  // Deliberately do NOT cache this fallback under `user_plan:${key}`. `key` is
+  // often a real user id (when an authenticated user's plan lookup transiently
+  // returns empty, e.g. a DB blip), and caching the free plan there would pin a
+  // paying customer to free-tier for the full 24h TTL — a single transient
+  // failure becomes a day-long outage for that account. The free plan is
+  // already cached independently via `free_plan` (getFreePlan), so skipping
+  // this adds no extra lookup cost.
   const { limiters, rateLimit } = rateLimiterUnion(plan, baseUrl);
 
   try {

--- a/apps/api/src/middlewares/rateLimiter.ts
+++ b/apps/api/src/middlewares/rateLimiter.ts
@@ -107,23 +107,15 @@ const rateLimiter = catchAsync(
           );
         }
       } catch (error) {
-        // Plan lookup failed (e.g. DB unreachable / stale connection). The user
-        // is demoted to free-tier; if this fires fleet-wide it's an outage, not
-        // a per-customer issue — log loudly with context.
-        logger.error(
-          error,
-          `rate limit: plan lookup failed for user ${id}, applying free plan`,
-        );
+        // Plan lookup errored -> free tier. A spike = DB outage, not per-customer.
+        logger.error(error, `rate limit: plan lookup failed for user ${id}, applying free plan`);
 
         return await useFreePlan(req, res, next, req.ip!);
       }
     }
 
     if (!selectedPlan) {
-      // Authenticated user resolved to no active plan -> free-tier limits.
-      // Expected for genuinely free accounts, but a spike across many users is
-      // the signature of a plan-resolution/DB outage (paying customers silently
-      // demoted and 429'd fleet-wide), so make it visible.
+      // No active plan -> free tier. A spike here = mass demotion (plan/DB outage).
       logger.warn(`rate limit: no active plan for user ${id}, applying free plan`);
 
       if (keyId) {
@@ -212,13 +204,8 @@ const useFreePlan = async (
 
   const plan = await getPlan(baseUrl, token);
 
-  // Deliberately do NOT cache this fallback under `user_plan:${key}`. `key` is
-  // often a real user id (when an authenticated user's plan lookup transiently
-  // returns empty, e.g. a DB blip), and caching the free plan there would pin a
-  // paying customer to free-tier for the full 24h TTL — a single transient
-  // failure becomes a day-long outage for that account. The free plan is
-  // already cached independently via `free_plan` (getFreePlan), so skipping
-  // this adds no extra lookup cost.
+  // Never cache this fallback under user_plan:${key}: for a real user id a
+  // transient empty lookup would pin them to free for 24h (free_plan is cached separately).
   const { limiters, rateLimit } = rateLimiterUnion(plan, baseUrl);
 
   try {


### PR DESCRIPTION
…tions

A transient empty plan lookup for an authenticated user caused useFreePlan to cache the FREE plan under user_plan:{userId} for 24h, pinning a paying customer to free-tier (429s) for a full day from a single blip. And when the auth/plan DB lookups fail fleet-wide (e.g. stale connections after a DB restore), every customer is silently demoted to free-tier with no clear signal.

- useFreePlan no longer writes user_plan:{key} (the free plan is already cached via free_plan); authenticated users re-resolve their real plan as soon as the DB returns it, instead of being stuck on free for 24h.
- Log when an authenticated user resolves to no plan, when the plan lookup throws, and when the auth token lookup throws — so a fleet-wide demotion is visible as an outage instead of hiding as per-customer 429s.