### PR TITLE
fix(frontend): mobile toolbar wrap and json-tree primitive copy noise

### DIFF
--- a/apps/api/src/middlewares/passport.ts
+++ b/apps/api/src/middlewares/passport.ts
@@ -58,7 +58,7 @@ const bearerVerify: VerifyFunction = async (token, done) => {
 
     // Token supplied but no matching user. A spike = silent mass demotion to free.
     logger.warn(
-      { token: token.slice(0, 6), hash: tokenHash(token) },
+      { hash: tokenHash(token), token: token.slice(0, 6) },
       'auth: bearer token did not resolve to a user, treating as anonymous',
     );
     return done(null, false);

--- a/apps/frontend/src/components/json-tree.tsx
+++ b/apps/frontend/src/components/json-tree.tsx
@@ -72,22 +72,23 @@ const Node = ({ depth = 0, isLast = true, name, value }: NodeProps) => {
   }
 
   if (!collapsible) {
+    // Plain inline flow (not inline-flex) so long strings with break-all
+    // wrap naturally after the label without splitting the row visually.
+    // Copy is shown only on strings — numbers/booleans/null are rarely
+    // worth copying and per-element copy on byte arrays is visual noise.
+    const showCopy = typeof value === 'string';
     return (
       <div className="group/node leading-relaxed">
-        <span className="inline-flex max-w-full items-center">
-          <span className="inline-flex items-center">
-            {label}
-            <Primitive value={value} />
-            {!isLast && <Punct>,</Punct>}
-          </span>
-          {value !== null && value !== undefined && (
-            <Copy
-              className="ml-1 size-5 opacity-0 transition-opacity group-hover/node:opacity-100"
-              size="icon-xs"
-              text={String(value)}
-            />
-          )}
-        </span>
+        {label}
+        <Primitive value={value} />
+        {!isLast && <Punct>,</Punct>}
+        {showCopy && (
+          <Copy
+            className="ml-1 inline-flex size-5 align-middle opacity-0 transition-opacity group-hover/node:opacity-100"
+            size="icon-xs"
+            text={value as string}
+          />
+        )}
       </div>
     );
   }

--- a/apps/frontend/src/components/txns/txn/execution/code.tsx
+++ b/apps/frontend/src/components/txns/txn/execution/code.tsx
@@ -52,9 +52,9 @@ export const CodeViewer = ({
 
   return (
     <div className="w-full min-w-0 overflow-hidden rounded border bg-(--prism-bg)">
-      <div className="bg-card/40 flex items-center justify-between gap-2 border-b px-2 py-1">
+      <div className="bg-card/40 flex flex-wrap items-center justify-between gap-x-2 gap-y-1 border-b px-2 py-1">
         <button
-          className="text-muted-foreground hover:text-foreground text-body-xs inline-flex items-center gap-1"
+          className="text-muted-foreground hover:text-foreground text-body-xs inline-flex shrink-0 items-center gap-1 whitespace-nowrap"
           onClick={() => setIsOpen((p) => !p)}
           type="button"
         >


### PR DESCRIPTION
- code.tsx toolbar now uses flex-wrap so the right-side controls flow to a second row on narrow viewports; the "Hide N bytes" button gets whitespace-nowrap + shrink-0 so its text stops wrapping mid-label
- json-tree primitive rows go back to plain inline flow (not inline-flex), so a long break-all string wraps under its key naturally instead of splitting the row visually above and below
- restrict the primitive hover-copy to strings; numbers/booleans/null no longer get per-element copy icons (eliminates the per-byte copy noise on number arrays like app_id)
