### PR TITLE
fix(indexer-accounts): store ML-DSA-65 access keys by their trie hash handle

### DIFF
--- a/apps/indexer-accounts/src/libs/utils.ts
+++ b/apps/indexer-accounts/src/libs/utils.ts
@@ -1,3 +1,4 @@
+import { createHash } from 'crypto';
 import { createRequire } from 'module';
 
 import { base58 } from '@scure/base';
@@ -6,7 +7,22 @@ import { ExecutionStatus } from 'nb-neardata';
 
 const json = createRequire(import.meta.url)('nb-json');
 
+const ML_DSA_HASH_DOMAIN = Buffer.from('near:ml-dsa-65-pubkey-hash:v1');
+
 export const jsonStringify = (args: unknown): string => json.stringify(args);
+
+// ML-DSA-65 keys are stored on the trie (and returned by RPC) as a short
+// hash handle, not the full ~1952-byte key. Canonicalize to that handle so the
+// value fits the access_keys btree index. Non-ML-DSA keys pass through unchanged.
+export const normalizeAccessKey = (publicKey: string): string => {
+  if (!publicKey.startsWith('ml-dsa-65:')) return publicKey; // ed25519/secp256k1, or already a handle
+  const raw = base58.decode(publicKey.slice('ml-dsa-65:'.length));
+  const digest = createHash('sha3-256')
+    .update(ML_DSA_HASH_DOMAIN)
+    .update(raw)
+    .digest();
+  return `ml-dsa-65-hash:${base58.encode(Uint8Array.from(digest))}`;
+};
 
 export const publicKeyFromImplicitAccount = (account: string) => {
   try {

--- a/apps/indexer-accounts/src/services/accessKey.ts
+++ b/apps/indexer-accounts/src/services/accessKey.ts
@@ -17,6 +17,7 @@ import {
 import {
   isExecutionSuccess,
   jsonStringify,
+  normalizeAccessKey,
   publicKeyFromImplicitAccount,
 } from '#libs/utils';
 
@@ -143,7 +144,8 @@ const getChunkAccessKeys = (
       }
 
       if (isAddKeyAction(action)) {
-        const { accessKey, publicKey } = action.AddKey;
+        const { accessKey } = action.AddKey;
+        const publicKey = normalizeAccessKey(action.AddKey.publicKey);
         const mapKey = `${accountId}:${publicKey}`;
         const keyToUpdate = accessKeysToUpdate.get(mapKey);
 
@@ -166,7 +168,7 @@ const getChunkAccessKeys = (
       }
 
       if (isDeleteKeyAction(action)) {
-        const { publicKey } = action.DeleteKey;
+        const publicKey = normalizeAccessKey(action.DeleteKey.publicKey);
         const mapKey = `${accountId}:${publicKey}`;
         const existingKey = accessKeys.get(mapKey);
 

--- a/apps/indexer-accounts/src/services/genesis.ts
+++ b/apps/indexer-accounts/src/services/genesis.ts
@@ -13,6 +13,7 @@ import { retry } from 'nb-utils';
 
 import config from '#config';
 import { db } from '#libs/knex';
+import { normalizeAccessKey } from '#libs/utils';
 import { getAccessKeyData, storeGenesisAccessKeys } from '#services/accessKey';
 import { getAccountData, storeGenesisAccounts } from '#services/account';
 
@@ -113,7 +114,7 @@ export const insertGenesisData = async (path: string) => {
     if (chunk.key === 'AccessKey') {
       const accessKeyData = getAccessKeyData(
         chunk.value.account_id,
-        chunk.value.public_key,
+        normalizeAccessKey(chunk.value.public_key),
         chunk.value.access_key.permission,
         config.genesisTimestamp,
       );


### PR DESCRIPTION
## Cause

ML-DSA-65 (protocol 2.13 post-quantum) access keys are stored verbatim into `access_keys`, whose primary key `(public_key, account_id)` is a `TEXT` btree. The full key is ~2676 bytes, so the index tuple exceeds Postgres's 2704-byte btree limit and the insert throws:

```
54000 index row size 2712 exceeds btree version 4 maximum 2704 for index "access_keys_pkey"
```

That's a `program_limit_exceeded` error, not a unique violation, so `.onConflict(['public_key','account_id']).merge()` doesn't catch it. It propagates and `indexer-accounts` calls `process.exit(1)` without advancing the sync cursor, so it crash-loops on that block. On testnet the accounts indexer is currently stuck at block 257423581 (the first ML-DSA AddKey).

## Fix

Canonicalize ML-DSA keys to the on-trie handle before storing:

```
ml-dsa-65-hash:base58( SHA3-256( "near:ml-dsa-65-pubkey-hash:v1" || raw_1952-byte_pubkey ) )
```

This is exactly what the trie stores and what RPC `view_access_key_list` returns (~59 chars, fits the btree). Applied at every `access_keys` write site — AddKey, DeleteKey, and genesis — via a `normalizeAccessKey` helper; ed25519/secp256k1 keys pass through unchanged. No schema migration and no new dependencies (`base58` is already imported; SHA3-256 comes from Node's `crypto`). Redeploying past the stuck block re-processes it successfully and the cursor catches up.

## Verified

Against a local Postgres with the migrated schema, feeding the real testnet block 257423581 through the real `storeAccessKeys` / `onMessage`:

- before: reproduces the 54000 error, `process.exit(1)`, cursor does not advance;
- after: the key is stored as `ml-dsa-65-hash:76goJ4uwwCubP53zdYLbJPor1EUpkG4f7PSUYKTV6BCU` (byte-for-byte matching testnet RPC) and the cursor advances past the block; a synthetic AddKey→DeleteKey for the same key resolves to the same handle row.

`tsc` and `eslint` clean.

---

Follow-ups out of scope here: `api` lookups of `access_keys` by public key should use the handle form for ML-DSA (as RPC does); global search and the keypair tool reject ML-DSA keys via an ed25519/secp256k1 allowlist.
