### PR TITLE
fix(frontend): dismiss rpc-session captcha after solving

### DIFF
--- a/apps/frontend/src/providers/rpc-session.tsx
+++ b/apps/frontend/src/providers/rpc-session.tsx
@@ -40,6 +40,9 @@ export const RpcSessionProvider = () => {
         onSuccess={(token) => {
           pending.current?.resolve(token);
           pending.current = null;
+          // interaction-only widgets stay visible showing the solved state;
+          // reset returns it to its dormant (hidden) state once we have the token.
+          widget.current?.reset();
         }}
         options={{
           appearance: 'interaction-only',


### PR DESCRIPTION
The interaction-only Turnstile widget stayed visible in the corner after a successful solve because onSuccess captured the token but never reset the widget. Reset it after resolving so it returns to its dormant, hidden state.
